### PR TITLE
docs: fix incorrect docker compose command in mirror node S3 setup

### DIFF
--- a/core-concepts/mirror-nodes/run-your-own-beta-mirror-node/run-your-own-mirror-node-s3.md
+++ b/core-concepts/mirror-nodes/run-your-own-beta-mirror-node/run-your-own-mirror-node-s3.md
@@ -106,7 +106,7 @@ Start and run the Hedera Mirror Node using Docker. Docker packages development t
 * From the mirror node directory, run the following command:
 
 ```bash
-docker compose up -d && docker logs hedera-mirror-node-importer-1 --follow
+docker compose up -d && docker logs hiero-mirror-node-importer-1 --follow
 ```
 
 ## 5. Access Your Mirror Node Data
@@ -121,10 +121,10 @@ docker ps
 
 <figure><img src="../../../.gitbook/assets/docker ps (1).png" alt=""><figcaption></figcaption></figure>
 
-* Run the following command to enter the `hedera-mirror-node-db-1` container:
+* Run the following command to enter the `hiero-mirror-node-db-1` container:
 
 ```bash
-docker exec -it hedera-mirror-node-db-1 bash
+docker exec -it hiero-mirror-node-db-1 bash
 ```
 
 * Enter the following command to access and query the database:


### PR DESCRIPTION
**Description**:
This PR modifies the documentation for setting up a mirror node using the S3 method in order to correct the docker compose command syntax and improve clarity for new users.

- Fix the incorrect Docker compose command in run-your-own-mirror-node-s3.md
- Align instructions with currently supported Docker usage

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #98

**Notes for reviewer**: No UI changes. Tested the updated docker compose command locally and confirmed it works as expected with the current setup. No further validation needed unless reviewers want to double-check.
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
