### PR TITLE
mainnet-nodes/node-requirements/README.md: proxy 50211/50212 is both ingress & egress

### DIFF
--- a/networks/mainnet/mainnet-nodes/node-requirements/README.md
+++ b/networks/mainnet/mainnet-nodes/node-requirements/README.md
@@ -180,7 +180,7 @@ The following ports must be configured for **public internet access** unless oth
 
 **📡 Port Configuration**
 
-<table><thead><tr><th width="132.375">Port</th><th width="129.4921875">Protocol</th><th width="170.046875">Direction</th><th>Purpose</th></tr></thead><tbody><tr><td><code>50211</code></td><td>TCP</td><td>Ingress</td><td>Gossip protocol</td></tr><tr><td><code>50212</code></td><td>TCP</td><td>Ingress</td><td>TLS-encrypted gossip</td></tr><tr><td><code>80</code></td><td>TCP</td><td>Egress only</td><td>OS package repository</td></tr><tr><td><code>443</code></td><td>TCP</td><td>Egress only</td><td>Secure updates</td></tr></tbody></table>
+<table><thead><tr><th width="132.375">Port</th><th width="129.4921875">Protocol</th><th width="170.046875">Direction</th><th>Purpose</th></tr></thead><tbody><tr><td><code>50211</code></td><td>TCP</td><td>Ingress/Egress</td><td>Gossip protocol</td></tr><tr><td><code>50212</code></td><td>TCP</td><td>Ingress/Egress</td><td>TLS-encrypted gossip</td></tr><tr><td><code>80</code></td><td>TCP</td><td>Egress only</td><td>OS package repository</td></tr><tr><td><code>443</code></td><td>TCP</td><td>Egress only</td><td>Secure updates</td></tr></tbody></table>
 
 </details>
 


### PR DESCRIPTION
**Description**:
This PR changes proxy connectivity ports 50211, 50212 from ingress to ingress/egress. 

![Brave Browser 2025-06-27 16 53 06](https://github.com/user-attachments/assets/c08643d5-107f-42c6-9b1b-ad1fda24baeb)

https://github.com/hashgraph/hedera-docs/blob/main/networks/mainnet/mainnet-nodes/node-requirements/README.md#network-configuration

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
