### PR TITLE
mainnet-nodes/node-requirements/README.md: nodes connectivity: 50111 to ingress & egress

### DIFF
--- a/networks/mainnet/mainnet-nodes/node-requirements/README.md
+++ b/networks/mainnet/mainnet-nodes/node-requirements/README.md
@@ -166,7 +166,7 @@ A proxy is required to expose the node’s public APIs.
 
 The following ports must be configured for **public internet access** unless otherwise stated:
 
-<table><thead><tr><th width="136.35546875">Port</th><th width="115.03515625">Protocol</th><th width="171.6953125">Direction</th><th>Description</th></tr></thead><tbody><tr><td><code>50111</code></td><td>TCP</td><td>Ingress</td><td>gRPC (public) API access</td></tr><tr><td><code>50211</code></td><td>TCP</td><td>Ingress</td><td>Gossip protocol</td></tr><tr><td><code>50212</code></td><td>TCP</td><td>Ingress</td><td>TLS-encrypted Gossip protocol</td></tr><tr><td><code>80</code></td><td>TCP</td><td>Egress only</td><td>OS package repository connectivity</td></tr><tr><td><code>443</code></td><td>TCP</td><td>Egress only</td><td>Secure package &#x26; system update access</td></tr><tr><td><code>123</code></td><td>UDP</td><td>Ingress/Egress</td><td>Time sync via NTP pool</td></tr></tbody></table>
+<table><thead><tr><th width="136.35546875">Port</th><th width="115.03515625">Protocol</th><th width="171.6953125">Direction</th><th>Description</th></tr></thead><tbody><tr><td><code>50111</code></td><td>TCP</td><td>Ingress/Egress</td><td>gRPC (public) API access</td></tr><tr><td><code>50211</code></td><td>TCP</td><td>Ingress</td><td>Gossip protocol</td></tr><tr><td><code>50212</code></td><td>TCP</td><td>Ingress</td><td>TLS-encrypted Gossip protocol</td></tr><tr><td><code>80</code></td><td>TCP</td><td>Egress only</td><td>OS package repository connectivity</td></tr><tr><td><code>443</code></td><td>TCP</td><td>Egress only</td><td>Secure package &#x26; system update access</td></tr><tr><td><code>123</code></td><td>UDP</td><td>Ingress/Egress</td><td>Time sync via NTP pool</td></tr></tbody></table>
 
 </details>
 


### PR DESCRIPTION
**Description**:
This PR changes nodes connectivity section for 50111 from ingress to ingress & egress.

![screenshot-20250627-23-58-13-UTC](https://github.com/user-attachments/assets/e91a0ace-fdc0-4bb4-97d4-7796ce0b5e00)

https://github.com/hashgraph/hedera-docs/blob/main/networks/mainnet/mainnet-nodes/node-requirements/README.md#network-configuration


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
