### PR TITLE
Docs/updates to Smart Contracts Tutorial #1

### DIFF
--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -329,15 +329,20 @@ Contract deployed at: 0xB3e022eBC7D5C5B1f4ca50b3D4A55173b34ceD49
 
 ---
 
-## Step 5: Deploy on Testnet
 
-If you would like to instead deploy and interact with testnet hedera network rather than a local hedera network, all you need to do is the following:
+{false && (
+  <>
+  ## Step 5: Deploy on Testnet
 
-```bash
-npx hardhat keystore set HEDERA_RPC_URL --force # Set this to "https://testnet.hashio.io/api"
-npx hardhat keystore set HEDERA_PRIVATE_KEY --force # Set this to your private key. Eg. 0xd434asdfa...
-npx hardhat run scripts/deploy.ts
-```
+  If you would like to instead deploy and interact with testnet hedera network rather than a local hedera network, all you need to do is the following:
+
+  ```bash
+  npx hardhat keystore set HEDERA_RPC_URL --force # Set this to "https://testnet.hashio.io/api"
+  npx hardhat keystore set HEDERA_PRIVATE_KEY --force # Set this to your private key. Eg. 0xd434asdfa...
+  npx hardhat run scripts/deploy.ts
+  ```
+  </>
+)}
 
 ## Further Learning & Next Steps
 

--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -20,6 +20,7 @@ Developers building smart contracts on Hedera often use the **Hedera JSON-RPC Re
 
 - Basic understanding of smart contracts.
 - Basic understanding of [Node.js](https://nodejs.org/en/download) and JavaScript/TypeScript.
+  - Have [nodejs](https://nodejs.org/en/download) installed on your local machine.
 - Basic understanding of [Hardhat EVM Development Tool](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3) and [Ethers](https://docs.ethers.org/v6/).
   - Have [hardhat](https://www.npmjs.com/package/hardhat) and [ethers](https://www.npmjs.com/package/ethers) installed on your local machine.
 - ECDSA account from the [Hedera Portal](https://portal.hedera.com/).
@@ -67,7 +68,7 @@ _📚 Learn more from the official_ [_Hardhat documentation_](https://hardhat.or
 Hedera provides a local node configuration that includes a mirror node, a consensus node, and the JSON-RPC relay. You can run it via `npm`.
 
 <Info>
-  If you are use Testnet instead of a local node, you can skip this step. Note that you will need to create a different config using a testnet private key and a public RPC URL.
+  If you are use Testnet instead of a local node, you can skip this step. 
 </Info>
 
 **Clone, install, and run the node:**

--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -66,6 +66,10 @@ _📚 Learn more from the official_ [_Hardhat documentation_](https://hardhat.or
 
 Hedera provides a local node configuration that includes a mirror node, a consensus node, and the JSON-RPC relay. You can run it via `npm`.
 
+<Info>
+  If you are use Testnet instead of a local node, you can skip this step. Note that you will need to create a different config using a testnet private key and a public RPC URL.
+</Info>
+
 **Clone, install, and run the node:**
 
 ```bash

--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -160,7 +160,7 @@ If you are using a local node, for the `HEDERA_PRIVATE_KEY`, enter `0x105d050185
   Local Node.
 </Info>
 
-If you are using Testnet, for the `HEDERA_PRIVATE_KEY`, enter your testnet HEX encoded private key which you can get by signing up on the [Hedera Developer Portal](https://portal.hedera.com/dashboard)
+If you are using Testnet, for the `HEDERA_PRIVATE_KEY`, enter your testnet **HEX Encoded Private Key for your ECDSA account** which you can get by signing up on the [Hedera Developer Portal](https://portal.hedera.com/dashboard)
 
 Now, we can update our Hardhat config file to include the Hiero Local Node as a custom network:
 

--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -143,19 +143,23 @@ Before we make any changes to our Hardhat configuration file, let's set some con
 npx hardhat keystore set HEDERA_RPC_URL
 ```
 
-For `HEDERA_RPC_URL`, we'll have `https://localhost:7546`
+If you are using a local node, set the `HEDERA_RPC_URL` to `https://localhost:7546`
+
+If you are use Testnet set `HEDERA_RPC_URL` to `https://testnet.hashio.io/api`.
 
 ```bash
 # If you have already set this before, please use the --force flag
 npx hardhat keystore set HEDERA_PRIVATE_KEY
 ```
 
-For `HEDERA_PRIVATE_KEY`, enter `0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524`
+If you are using a local node, for the `HEDERA_PRIVATE_KEY`, enter `0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524`
 
 <Info>
   **Note:** We got this private key from our console when we started our Hiero
   Local Node.
 </Info>
+
+If you are using Testnet, for the `HEDERA_PRIVATE_KEY`, enter your testnet ECDSA EVM private key which you can get by signing up on the [Hedera Developer Portal](https://portal.hedera.com/dashboard)
 
 Now, we can update our Hardhat config file to include the Hiero Local Node as a custom network:
 

--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -21,6 +21,7 @@ Developers building smart contracts on Hedera often use the **Hedera JSON-RPC Re
 - Basic understanding of smart contracts.
 - Basic understanding of [Node.js](https://nodejs.org/en/download) and JavaScript/TypeScript.
 - Basic understanding of [Hardhat EVM Development Tool](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3) and [Ethers](https://docs.ethers.org/v6/).
+  - Have [hardhat](https://www.npmjs.com/package/hardhat) and [ethers](https://www.npmjs.com/package/ethers) installed on your local machine.
 - ECDSA account from the [Hedera Portal](https://portal.hedera.com/).
 
 ---

--- a/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
+++ b/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide.mdx
@@ -159,7 +159,7 @@ If you are using a local node, for the `HEDERA_PRIVATE_KEY`, enter `0x105d050185
   Local Node.
 </Info>
 
-If you are using Testnet, for the `HEDERA_PRIVATE_KEY`, enter your testnet ECDSA EVM private key which you can get by signing up on the [Hedera Developer Portal](https://portal.hedera.com/dashboard)
+If you are using Testnet, for the `HEDERA_PRIVATE_KEY`, enter your testnet HEX encoded private key which you can get by signing up on the [Hedera Developer Portal](https://portal.hedera.com/dashboard)
 
 Now, we can update our Hardhat config file to include the Hiero Local Node as a custom network:
 

--- a/hedera/tutorials/smart-contracts/how-to-mint-and-burn-an-erc-721-token-using-hardhat-and-ethers-part-1.mdx
+++ b/hedera/tutorials/smart-contracts/how-to-mint-and-burn-an-erc-721-token-using-hardhat-and-ethers-part-1.mdx
@@ -99,7 +99,7 @@ npm install @openzeppelin/contracts
 Before we make any changes to our Hardhat configuration file, let's set some configuration variables we will be referring to within the file later.
 
 ```bash
-# If you have already set this before, please use the --force flag
+# If you have already set a different one before, please use the --force flag to overwrite a new variable
 npx hardhat keystore set HEDERA_RPC_URL
 ```
 
@@ -408,7 +408,7 @@ async function main() {
 
   // Connect to the deployed contract
   // (REPLACE WITH YOUR CONTRACT ADDRESS)
-  const contractAddress = "0x00f2753A689C3bdd1a733430c7b63A3993B1eFBc";
+  const contractAddress = "<your-contract-address>";
   const contract = MyToken.attach(contractAddress);
 
   // Burn the token

--- a/hedera/tutorials/smart-contracts/how-to-mint-and-burn-an-erc-721-token-using-hardhat-and-ethers-part-1.mdx
+++ b/hedera/tutorials/smart-contracts/how-to-mint-and-burn-an-erc-721-token-using-hardhat-and-ethers-part-1.mdx
@@ -99,14 +99,14 @@ npm install @openzeppelin/contracts
 Before we make any changes to our Hardhat configuration file, let's set some configuration variables we will be referring to within the file later.
 
 ```bash
-# If you have already set a different one before, please use the --force flag to overwrite a new variable
+# If you have set a different one before, use the --force flag to overwrite
 npx hardhat keystore set HEDERA_RPC_URL
 ```
 
 For `HEDERA_RPC_URL`, we'll have `https://testnet.hashio.io/api`
 
 ```bash
-# If you have already set this before, please use the --force flag
+# If you have set a different one before, use the --force flag 
 npx hardhat keystore set HEDERA_PRIVATE_KEY
 ```
 


### PR DESCRIPTION
**Description**:
This PR modifies Some Docs in `tutorials/smart-contracts` so users can also onboard to testnet.

I noticed this is at the end (Step 5) but as a user, I didn't think to look at the end when I wanted to run on testnet, so I added it inline instead for a more natural flow. Just a suggestion.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
The name of the page is [Configuring Hardhat with Hedera Localnet/Testnet](https://docs.hedera.com/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide#step-3:-configure-%E2%80%9Chardhat-config-ts%E2%80%9D) but has no instructions for testnet -- adding those in, plus links to packages that need installing.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

No docs on how to run tests
