### PR TITLE
Fix broken links oracle page

### DIFF
--- a/hedera/open-source-solutions/oracle-networks.mdx
+++ b/hedera/open-source-solutions/oracle-networks.mdx
@@ -11,19 +11,19 @@ Hedera supports integration with multiple oracle networks, each offering unique 
   <Card
     title="PYTH"
     img="/images/open-source-solutions/oracle-networks/image.jpg"
-    href="hedera/open-source-solutions/oracle-networks/pyth-network-oracle.mdx"
+    href="/hedera/open-source-solutions/oracle-networks/pyth-network-oracle"
     arrow
 />
   <Card
     title="SUPRA"
     img="/images/open-source-solutions/oracle-networks/image2.jpg"
-    href="hedera/open-source-solutions/oracle-networks/supra-oracles.mdx"
+    href="/hedera/open-source-solutions/oracle-networks/supra-oracles"
     arrow
 />
   <Card
     title="CHAINLINK"
     img="/images/open-source-solutions/oracle-networks/image3.jpg"
-    href="hedera/open-source-solutions/oracle-networks/chainlink-oracles.mdx"
+    href="/hedera/open-source-solutions/oracle-networks/chainlink-oracles"
     arrow
 />
 </Columns>


### PR DESCRIPTION
Fix fot he broken links on the oracles page under Open Source Solutions.

Fixes #384 