### PR TITLE
docs: Add Ubuntu 24 LTS to list of supported OS

### DIFF
--- a/hedera/networks/mainnet/mainnet-nodes/node-requirements.mdx
+++ b/hedera/networks/mainnet/mainnet-nodes/node-requirements.mdx
@@ -81,7 +81,7 @@ If mounted to root volume, the root volume must meet these requirements. If prov
 #### Supported OS
 
 - Supported Linux Distributions (64-bit, LTS only):
-  - Ubuntu 22.04 LTS
+  - Ubuntu 22.04 LTS and 24.04 LTS
   - Red Hat Enterprise Linux (RHEL) 8 and 9
   - Oracle Linux 8 and 9
 - Supported kernel versions:


### PR DESCRIPTION
**Description**:
This PR updates documentation to describe Ubuntu 24 LTS as a supported OS

**Related issue(s)**:

Fixes #481 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
