### PR TITLE
docs(stablecoin-studio): fix broken TypeScript SDK / Smart Contracts links

### DIFF
--- a/hedera/open-source-solutions/stablecoin-studio/core-concepts.mdx
+++ b/hedera/open-source-solutions/stablecoin-studio/core-concepts.mdx
@@ -30,7 +30,7 @@ The core components of Stablecoin Studio include these four components that help
 <Columns cols={2}>
   <Card
     title="TypeScript SDK"
-    href="https://github.com/hashgraph/stablecoin-studio/blob/main/sdk/README.md"
+    href="https://github.com/hashgraph/stablecoin-studio/tree/main/documentation/sdk"
     arrow
     img="/images/open-source-solutions/stablecoin-studio/core-concepts/core-concepts-3.png"
   >
@@ -57,7 +57,7 @@ A command line interface (CLI) tool for creating, managing, and operating stable
   </Card>
   <Card
     title="Smart Contracts"
-    href="https://github.com/hashgraph/stablecoin-studio/blob/main/contracts/README.md"
+    href="https://github.com/hashgraph/stablecoin-studio/tree/main/documentation/contracts"
     arrow
     img="/images/open-source-solutions/stablecoin-studio/core-concepts/core-concepts-6.png"
   >


### PR DESCRIPTION
## Summary

Per #509, the Core Concepts page had two broken links:

- \`https://github.com/hashgraph/stablecoin-studio/blob/main/sdk/README.md\` (404)
- \`https://github.com/hashgraph/stablecoin-studio/blob/main/contracts/README.md\` (404)

The \`stablecoin-studio\` repo now has no top-level \`sdk/\` or \`contracts/\` directories; the SDK source lives at \`packages/sdk/\` and the SDK documentation lives at \`documentation/sdk/\`. For a \"TypeScript SDK\" / \"Smart Contracts\" *reference link* from a docs page, pointing at the documentation tree reads better:

- \`https://github.com/hashgraph/stablecoin-studio/tree/main/documentation/sdk\`
- \`https://github.com/hashgraph/stablecoin-studio/tree/main/documentation/contracts\`

Both return 200 now.

Closes #509

## Testing

\`\`\`
$ curl -sI https://github.com/hashgraph/stablecoin-studio/tree/main/documentation/sdk | head -1
HTTP/2 200
$ curl -sI https://github.com/hashgraph/stablecoin-studio/tree/main/documentation/contracts | head -1
HTTP/2 200
\`\`\`

Happy to re-point at \`packages/sdk\` / \`packages/contracts\` if the docs team prefers linking to source trees instead of documentation trees.