### PR TITLE
docs: update-hiero-cli

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -515,6 +515,7 @@
                     "pages": [
                       "/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",

--- a/docs.json
+++ b/docs.json
@@ -513,19 +513,19 @@
                   {
                     "group": "Plugins",
                     "pages": [
+                      "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/account-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/token-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/topic-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/config-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/plugin-management-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/account-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/token-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/topic-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/config-plugin",
-                      "/hedera/open-source-solutions/hiero-cli/plugins/plugin-management-plugin"
+                      "/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin"
                     ]
                   },
                   {

--- a/docs.json
+++ b/docs.json
@@ -516,6 +516,7 @@
                       "/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",

--- a/docs.json
+++ b/docs.json
@@ -517,6 +517,7 @@
                       "/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",

--- a/docs.json
+++ b/docs.json
@@ -514,6 +514,7 @@
                     "group": "Plugins",
                     "pages": [
                       "/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin",
+                      "/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",

--- a/docs.json
+++ b/docs.json
@@ -513,6 +513,7 @@
                   {
                     "group": "Plugins",
                     "pages": [
+                      "/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/network-plugin",
                       "/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin",

--- a/hedera/open-source-solutions.mdx
+++ b/hedera/open-source-solutions.mdx
@@ -25,7 +25,7 @@ sidebarTitle: "Overview"
 <Card title="HashioDAO" href="/hedera/open-source-solutions/hashiodao" />
 
 {" "}
-<Card title="Hedera CLI" href="/hedera/open-source-solutions/hiero-cli" />
+<Card title="Hiero CLI" href="/hedera/open-source-solutions/hiero-cli" />
 
 {" "}
 <Card

--- a/hedera/open-source-solutions/hiero-cli/overview.mdx
+++ b/hedera/open-source-solutions/hiero-cli/overview.mdx
@@ -220,7 +220,7 @@ Use an operator key and account ID that match **your** local node setup; the val
 
 ## Plugins Overview
 
-The CLI loads a fixed set of default plugins. The pages below document most of them. Full docs pages for **Schedule**, **Contract**, **Contract ERC-20**, and **Contract ERC-721** are still planned—until then, those cards link to the plugin README in the Hiero CLI GitHub repository.
+The CLI loads a fixed set of default plugins. The pages below document most of them. Full docs pages for **Contract**, **Contract ERC-20**, and **Contract ERC-721** are still planned—until then, those cards link to the plugin README in the Hiero CLI GitHub repository.
 
 <Card
   title="Network Plugin"
@@ -297,10 +297,10 @@ The CLI loads a fixed set of default plugins. The pages below document most of t
 <Card
   title="Schedule Plugin"
   icon="puzzle-piece-simple"
-  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/schedule/README.md"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin"
   horizontal
 >
-  Create, sign, delete, and verify scheduled transactions (README in repo)
+  Create, sign, delete, and verify Hedera scheduled transactions
 </Card>
 <Card
   title="Contract Plugin"

--- a/hedera/open-source-solutions/hiero-cli/overview.mdx
+++ b/hedera/open-source-solutions/hiero-cli/overview.mdx
@@ -220,7 +220,7 @@ Use an operator key and account ID that match **your** local node setup; the val
 
 ## Plugins Overview
 
-The CLI loads a fixed set of default plugins. The pages below document most of them. A full docs page for **Contract ERC-721** is still planned—until then, that card links to the plugin README in the Hiero CLI GitHub repository.
+The CLI loads a fixed set of default plugins. The pages below document the shipped plugins and their CLI commands.
 
 <Card
   title="Network Plugin"
@@ -321,10 +321,10 @@ The CLI loads a fixed set of default plugins. The pages below document most of t
 <Card
   title="Contract ERC-721 Plugin"
   icon="puzzle-piece-simple"
-  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract-erc721/README.md"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin"
   horizontal
 >
-  Call ERC-721 (NFT) contract functions (README in repo)
+  Call ERC-721 view and state-changing functions on deployed NFT contracts
 </Card>
 
 ## Scripting

--- a/hedera/open-source-solutions/hiero-cli/overview.mdx
+++ b/hedera/open-source-solutions/hiero-cli/overview.mdx
@@ -220,7 +220,7 @@ Use an operator key and account ID that match **your** local node setup; the val
 
 ## Plugins Overview
 
-The CLI loads a fixed set of default plugins. The pages below document most of them; for **Batch**, **Schedule**, **Contract**, **Contract ERC-20**, and **Contract ERC-721**, full docs pages are planned—until then, each card links to the plugin README in the Hiero CLI GitHub repository.
+The CLI loads a fixed set of default plugins. The pages below document most of them. Full docs pages for **Schedule**, **Contract**, **Contract ERC-20**, and **Contract ERC-721** are still planned—until then, those cards link to the plugin README in the Hiero CLI GitHub repository.
 
 <Card
   title="Network Plugin"
@@ -289,10 +289,10 @@ The CLI loads a fixed set of default plugins. The pages below document most of t
 <Card
   title="Batch Plugin"
   icon="puzzle-piece-simple"
-  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/batch/README.md"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin"
   horizontal
 >
-  Create, execute, list, and delete batches of transactions (README in repo)
+  Create, execute, list, and delete batches of Hedera transactions
 </Card>
 <Card
   title="Schedule Plugin"

--- a/hedera/open-source-solutions/hiero-cli/overview.mdx
+++ b/hedera/open-source-solutions/hiero-cli/overview.mdx
@@ -4,53 +4,61 @@ title: "Overview"
 
 ## Introduction to Hiero CLI
 
-The [Hiero CLI ](https://github.com/hiero-ledger/hiero-cli) is a command‑line interface that offers a simple way to interact with the Hedera network. It consolidates many common network operations into easy-to‑use commands so you can:
+The [Hiero CLI](https://github.com/hiero-ledger/hiero-cli) is a command‑line interface that offers a simple way to interact with the Hedera network. It consolidates many common network operations into easy-to‑use commands so you can:
 
-* **Test** your Hedera applications quickly.
-* **Automate** repetitive tasks without writing bulky code.
-* **Simplify** key management, letting you focus on building and scaling your solutions.
+- **Test** your Hedera applications quickly.
+- **Automate** repetitive tasks without writing bulky code.
+- **Simplify** key management, letting you focus on building and scaling your solutions.
 
-***
+---
 
 ## Getting Started
 
 **Prerequisites**:
 
-* Node.js installation: LTS 16.20.2 or higher
-* [Hedera Account](https://portal.hedera.com/) (for mainnet, testnet, or previewnet) or [Hedera Local Node](/hedera/tutorials/local-node/how-to-set-up-a-hedera-local-node) (for localnet)
+- Node.js installation: 18.0.0 or higher
+- [Hedera Account](https://portal.hedera.com/) (for mainnet, testnet, or previewnet) or [Hedera Local Node](/hedera/tutorials/local-node/how-to-set-up-a-hedera-local-node) (for localnet)
 
-The easiest way to get started with Hiero CLI is to install it globally via NPM:
+Install the CLI globally with npm:
 
 ```
 npm install -g @hiero-ledger/hiero-cli
 ```
 
-Once installed, you can use the CLI with the `hcli` command:
+On macOS you can also install with [Homebrew](https://brew.sh/):
+
+```sh
+brew install hiero-ledger/tools/hiero-cli
+```
+
+Once installed, use the `hcli` command:
 
 ```sh
 # Check available commands
 hcli --help
 
 # Example: Check account balance
-hcli account balance --account-id 0.0.123456
+hcli account balance --account 0.0.123456
 
 # Example: Transfer HBAR
 hcli hbar transfer --to 0.0.123456 --amount 10
 ```
 
 <Note>
-#### **First-time setup (Initialization):** 
-When you run any command that requires an operator (like transferring HBAR or creating tokens) in interactive mode, the CLI will automatically launch an initialization wizard to guide you through configuring the operator account, private key, and settings. In script mode (non-interactive), an error will be thrown instead, requiring you to use `hcli` network set-operator to configure the operator first.
+#### **First-time setup (Initialization):**
+
+When you run any command that requires an operator (like transferring HBAR or creating tokens) in interactive mode, the CLI will automatically launch an initialization wizard to guide you through configuring the operator account, private key, and settings. In script mode (non-interactive), an error will be thrown instead, requiring you to use `hcli network set-operator` to configure the operator first.
+
 </Note>
 
-<Accordion title="Manual Setup (Build custom plugins)" icon="alien-8bit">
+<Accordion title="Manual Setup (For Developers)" icon="alien-8bit">
     ## Manual Setup (For Developers)
 
-    If you want to contribute to the development of the Hiero CLI or create your own version or plugins, follow these instructions.
+    If you want to contribute to the development of the Hiero CLI or run it from source, follow these instructions.
 
-    **Prerequisites** 
+    **Prerequisites**
 
-    * Node.js installation: LTS 16.20.2 or higher
+    * Node.js installation: 18.0.0 or higher
     * [Hedera Account](https://portal.hedera.com/) (for mainnet, testnet, or previewnet) or [Hedera Local Node](/hedera/tutorials/local-node/how-to-set-up-a-hedera-local-node) (for localnet)
     * Git
 
@@ -71,7 +79,7 @@ When you run any command that requires an operator (like transferring HBAR or cr
 
     ```sh
     npm run build
-    ``` 
+    ```
 
     **Step 4: CLI Initialization**
 
@@ -84,7 +92,7 @@ When you run any command that requires an operator (like transferring HBAR or cr
     * Register all plugin commands
     * Use testnet as the default network
 
-    **Note:** There is a test plugin available that is required for running integration tests.
+    **Note:** There is a test plugin in the repository that is required for running integration tests.
 
     You can verify the installation by checking available commands:
 
@@ -109,7 +117,7 @@ When you run any command that requires an operator (like transferring HBAR or cr
 
     The operator credentials are stored in the CLI's state management system. Make sure that each operator account contains at least 1 HBAR for transaction fees.
 
-    **Step 6: Setting Up an Alias (Optional)
+    **Step 6: Setting Up an Alias (Optional)**
 
     To avoid typing the full command each time, you can set an alias in your shell profile. Replace the path with the absolute path to your hiero-cli installation.
 
@@ -126,7 +134,7 @@ When you run any command that requires an operator (like transferring HBAR or cr
         ```sh
         # For bash
         source ~/.bashrc
-        
+
         # or
         source ~/.bash_profile
 
@@ -161,48 +169,174 @@ When you run any command that requires an operator (like transferring HBAR or cr
         Now you can use `hcli` with arguments just like on Unix systems.
     </Tab>
     </Tabs>
+
 </Accordion>
 
 ## Global Flags
 
-These flags are available on **all Hiero CLI commands**. They control output, help, and versioning, regardless of the specific plugin or command you’re using.
+These options are defined on the root `hcli` program (see `hcli --help`). They work together with each command’s own flags.
 
-- `--format <type>`: Controls how command output is formatted.<br/>Supported values `human` (default) or `json` for machine-readable output.
-- `-h, --help`: Displays help information for a command.
-- `-V, --version`: Outputs the installed Hiero CLI version.
+- `--format <type>`: Output format: `human` (default) or `json` for machine-readable output.
+- `-N, --network <network>`: Target network: `testnet`, `mainnet`, `previewnet`, or `localnet`. Runs the command against this network without necessarily changing your saved default (see the Network plugin for switching defaults).
+- `-P, --payer <payer>`: Payer for transactions in this command: account alias, or `account-id:private-key` format. Overrides the default operator as payer when supported by the command.
+- `--confirm`: Skip interactive confirmation prompts for commands that would otherwise ask for confirmation (for example, some delete operations).
+- `-h, --help`: Show help for the current command.
+- `-V, --version`: Print the installed Hiero CLI version.
+
+## Configuration and State
+
+Runtime state (accounts, tokens, operator settings, and other plugin data) is stored under your home directory by default:
+
+- **Default directory:** `~/.hiero-cli/state/`
+
+Each plugin uses its own JSON files there. You normally should not edit them by hand.
+
+**Key storage** supports two modes:
+
+- **`local`** — keys stored in plain text in the state directory (typical for development)
+- **`local_encrypted`** — keys encrypted with AES-256-GCM before storage (stronger protection)
+
+Set the default storage mode with the [Config plugin](/hedera/open-source-solutions/hiero-cli/plugins/config-plugin):
+
+```sh
+hcli config set -o default_key_manager -v local
+hcli config set -o default_key_manager -v local_encrypted
+```
+
+Override per command with `--key-manager` where the command supports it (for example `account import` or `network set-operator`). Details are covered in the plugin reference pages.
+
+## Local Hedera Network (Localnet)
+
+To use the CLI against a [local Hedera node](/hedera/tutorials/local-node/how-to-set-up-a-hedera-local-node), configure an operator for `localnet` and select that network. Default connection settings shipped with the CLI match the usual local node layout (see `src/core/services/network/network.config.ts` in the [Hiero CLI repository](https://github.com/hiero-ledger/hiero-cli)).
+
+Example:
+
+```sh
+hcli network set-operator --operator 0.0.2:302e020100300506032b65700123456789132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137 --network localnet
+hcli network use --global localnet
+```
+
+Use an operator key and account ID that match **your** local node setup; the values above are only an illustration from the Hiero CLI README.
 
 ## Plugins Overview
 
-<Card title="Credentials Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin" horizontal>
-  Manage operator credentials and keys
-</Card>
-<Card title="Network Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/network-plugin" horizontal>
+The CLI loads a fixed set of default plugins. The pages below document most of them; for **Batch**, **Schedule**, **Contract**, **Contract ERC-20**, and **Contract ERC-721**, full docs pages are planned—until then, each card links to the plugin README in the Hiero CLI GitHub repository.
+
+<Card
+  title="Network Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/network-plugin"
+  horizontal
+>
   Switch networks, manage operator credentials, and check network health
 </Card>
-<Card title="HBAR Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin" horizontal>
-  Transfer HBAR between accounts
+<Card
+  title="Credentials Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/credentials-plugin"
+  horizontal
+>
+  Manage operator credentials and keys
 </Card>
-<Card title="Account Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/account-plugin" horizontal>
+<Card
+  title="Account Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/account-plugin"
+  horizontal
+>
   Create, import, manage accounts, and view balances
 </Card>
-<Card title="Token Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/token-plugin" horizontal>
+<Card
+  title="HBAR Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin"
+  horizontal
+>
+  Transfer HBAR between accounts
+</Card>
+<Card
+  title="Token Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/token-plugin"
+  horizontal
+>
   Create, associate, and transfer tokens
 </Card>
-<Card title="Topic Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/topic-plugin" horizontal>
+<Card
+  title="Topic Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/topic-plugin"
+  horizontal
+>
   Create topics and manage topic messages
 </Card>
-<Card title="Config Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/config-plugin" horizontal>
+<Card
+  title="Config Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/config-plugin"
+  horizontal
+>
   Inspect and update CLI configuration values
 </Card>
-<Card title="Plugin Management Plugin" icon="puzzle-piece-simple" href="/hedera/open-source-solutions/hiero-cli/plugins/plugin-management-plugin" horizontal>
+<Card
+  title="Plugin Management Plugin"
+  icon="puzzle-piece-simple"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/plugin-management-plugin"
+  horizontal
+>
   Add, remove, enable/disable, and inspect plugins
 </Card>
+<Card
+  title="Batch Plugin"
+  icon="puzzle-piece-simple"
+  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/batch/README.md"
+  horizontal
+>
+  Create, execute, list, and delete batches of transactions (README in repo)
+</Card>
+<Card
+  title="Schedule Plugin"
+  icon="puzzle-piece-simple"
+  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/schedule/README.md"
+  horizontal
+>
+  Create, sign, delete, and verify scheduled transactions (README in repo)
+</Card>
+<Card
+  title="Contract Plugin"
+  icon="puzzle-piece-simple"
+  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract/README.md"
+  horizontal
+>
+  Compile, deploy, and verify Solidity smart contracts (README in repo)
+</Card>
+<Card
+  title="Contract ERC-20 Plugin"
+  icon="puzzle-piece-simple"
+  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract-erc20/README.md"
+  horizontal
+>
+  Call ERC-20 contract functions (README in repo)
+</Card>
+<Card
+  title="Contract ERC-721 Plugin"
+  icon="puzzle-piece-simple"
+  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract-erc721/README.md"
+  horizontal
+>
+  Call ERC-721 (NFT) contract functions (README in repo)
+</Card>
 
-## Scripting 
+## Scripting
 
 Once you’re familiar with the available CLI commands, you can take the next step with scripting. Scripting is especially useful for CI/CD pipelines, setting up test environments, and automating repeated workflows.
 
-<Card title="Scripting Quickstart" icon="scroll" href="/hedera/open-source-solutions/hiero-cli/scripting/quickstart" horizontal>
+<Card
+  title="Scripting Quickstart"
+  icon="scroll"
+  href="/hedera/open-source-solutions/hiero-cli/scripting/quickstart"
+  horizontal
+>
   Learn how to create your first script using Hiero CLI commands.
 </Card>
 
@@ -211,5 +345,6 @@ Once you’re familiar with the available CLI commands, you can take the next st
 <Tip>
 ### 💡 Feature Requests?
 
-Feel free to contribute to the Hiero CLI or submit a feature request or bug via the [**issues tab**](https://github.com/hiero-ledger/hiero-cli/issues)**.**
+Feel free to contribute to the Hiero CLI or submit a feature request or bug via the [**issues tab**](https://github.com/hiero-ledger/hiero-cli/issues).
+
 </Tip>

--- a/hedera/open-source-solutions/hiero-cli/overview.mdx
+++ b/hedera/open-source-solutions/hiero-cli/overview.mdx
@@ -220,7 +220,7 @@ Use an operator key and account ID that match **your** local node setup; the val
 
 ## Plugins Overview
 
-The CLI loads a fixed set of default plugins. The pages below document most of them. Full docs pages for **Contract ERC-20** and **Contract ERC-721** are still planned—until then, those cards link to the plugin README in the Hiero CLI GitHub repository.
+The CLI loads a fixed set of default plugins. The pages below document most of them. A full docs page for **Contract ERC-721** is still planned—until then, that card links to the plugin README in the Hiero CLI GitHub repository.
 
 <Card
   title="Network Plugin"
@@ -313,10 +313,10 @@ The CLI loads a fixed set of default plugins. The pages below document most of t
 <Card
   title="Contract ERC-20 Plugin"
   icon="puzzle-piece-simple"
-  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract-erc20/README.md"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin"
   horizontal
 >
-  Call ERC-20 contract functions (README in repo)
+  Call ERC-20 view and state-changing functions on deployed contracts
 </Card>
 <Card
   title="Contract ERC-721 Plugin"

--- a/hedera/open-source-solutions/hiero-cli/overview.mdx
+++ b/hedera/open-source-solutions/hiero-cli/overview.mdx
@@ -220,7 +220,7 @@ Use an operator key and account ID that match **your** local node setup; the val
 
 ## Plugins Overview
 
-The CLI loads a fixed set of default plugins. The pages below document most of them. Full docs pages for **Contract**, **Contract ERC-20**, and **Contract ERC-721** are still planned—until then, those cards link to the plugin README in the Hiero CLI GitHub repository.
+The CLI loads a fixed set of default plugins. The pages below document most of them. Full docs pages for **Contract ERC-20** and **Contract ERC-721** are still planned—until then, those cards link to the plugin README in the Hiero CLI GitHub repository.
 
 <Card
   title="Network Plugin"
@@ -305,10 +305,10 @@ The CLI loads a fixed set of default plugins. The pages below document most of t
 <Card
   title="Contract Plugin"
   icon="puzzle-piece-simple"
-  href="https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract/README.md"
+  href="/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin"
   horizontal
 >
-  Compile, deploy, and verify Solidity smart contracts (README in repo)
+  Compile, deploy, import, list, and delete Solidity smart contracts
 </Card>
 <Card
   title="Contract ERC-20 Plugin"

--- a/hedera/open-source-solutions/hiero-cli/plugins/account-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/account-plugin.mdx
@@ -29,8 +29,8 @@ hcli account list
 <Accordion title="Account Create">
     Creates a new Hedera account.
 
-    <ResponseField name="-b, --balance" type="int" required>
-    Initial HBAR balance. Add "t" for Tinybar units <br/>
+    <ResponseField name="-b, --balance" type="string" required>
+    Initial HBAR balance. Default: display units. Add "t" for Tinybar units <br/>
     `--balance 10`   --> 10 HBAR <br/>
     `--balance 100t` --> 100 Tinybars
     </ResponseField>
@@ -40,20 +40,64 @@ hcli account list
         Default value set to 0
     </ResponseField>
 
+    <ResponseField name="-n, --name" type="string">
+        Alias of the created account to be used
+    </ResponseField>
+
     <ResponseField name="-k, --key-manager" type="string">
         Key manager to use: `local` or `local_encrypted` (defaults to config setting) <br/>
     </ResponseField>
 
-    <ResponseField name="-n, --name" type="string" required>
-        Alias of the created account to be used <br/>
-    </ResponseField>
-
     <ResponseField name="-t, --key-type" type="string(ecdsa|ed25519)">
-        Set the default key type. Defaults to ecdsa (recommended for full usability) <br/>
+        Key type for the account. Default: ecdsa. Mutually exclusive with `--key`.
     </ResponseField>
 
-    <ResponseField name="-p, --payer" type="string">
-        Set the payer account, can be an account ID or alias
+    <ResponseField name="-K, --key" type="string">
+        Existing key for the new account (ecdsa/ed25519 private or public key, key reference `kr_xxx`, or alias name). Mutually exclusive with `--key-type`.
+    </ResponseField>
+</Accordion>
+
+<Accordion title="Account Update">
+    Update properties of an existing Hedera account on-chain.
+
+    <ResponseField name="-a, --account" type="string" required>
+        Account ID or alias of the account to update
+    </ResponseField>
+
+    <ResponseField name="-K, --key" type="string">
+        New key for the account (private/public key, key reference, or alias). Requires private key in KMS.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting)
+    </ResponseField>
+
+    <ResponseField name="-m, --memo" type="string">
+        Account memo (max 100 characters). Pass `null` to clear.
+    </ResponseField>
+
+    <ResponseField name="--max-auto-associations" type="number">
+        Max automatic token associations (-1 for unlimited, 0 to disable)
+    </ResponseField>
+
+    <ResponseField name="--staked-account-id" type="string">
+        Account ID to stake to. Pass `null` to clear.
+    </ResponseField>
+
+    <ResponseField name="--staked-node-id" type="number">
+        Node ID to stake to. Pass `null` to clear.
+    </ResponseField>
+
+    <ResponseField name="--decline-staking-reward" type="boolean">
+        Decline staking reward
+    </ResponseField>
+
+    <ResponseField name="--auto-renew-period" type="number">
+        Auto renew period in seconds
+    </ResponseField>
+
+    <ResponseField name="--receiver-signature-required" type="boolean">
+        Require receiver signature for transfers
     </ResponseField>
 </Accordion>
 
@@ -64,8 +108,8 @@ hcli account list
         Specify the private key in `accountId:privateKey` format (e.g., "`0.0.123456:abc123...`")
     </ResponseField>
 
-    <ResponseField name="-n, --name" type="string" required>
-        Alias for the account to be used
+    <ResponseField name="-n, --name" type="string">
+        Name of the account to be used
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string">
@@ -114,13 +158,17 @@ hcli account list
 </Accordion>
 
 <Accordion title="Account Delete">
-    Delete an account from the address book. You need to specify either name or ID to delete the account.
+    Delete an account on Hedera and remove it from local state if present, or remove from local state only with `--state-only`. On-chain delete requires `--transfer-id` for the beneficiary account.
 
-    <ResponseField name="-n, --name" type="string">
-        Account name to be deleted from the store.
+    <ResponseField name="-a, --account" type="string" required>
+        With `--state-only`: Hedera account ID or local alias. Otherwise: account key (ID, `id:private key`, key reference, alias with stored key, etc.)
     </ResponseField>
 
-    <ResponseField name="-i, --id" type="string">
-        Account ID to be deleted from the store.
+    <ResponseField name="-t, --transfer-id" type="string">
+        Required when deleting on Hedera: account that receives remaining HBAR (Hedera ID or alias). Mutually exclusive with `--state-only`.
+    </ResponseField>
+
+    <ResponseField name="-s, --state-only">
+        Remove the account only from local CLI state. Do not submit AccountDeleteTransaction. Mutually exclusive with `--transfer-id`.
     </ResponseField>
 </Accordion>

--- a/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin.mdx
@@ -1,0 +1,130 @@
+---
+title: "Batch Plugin"
+---
+
+## Most Used Commands
+
+**Create a batch, queue two token creates, then execute**
+
+```sh
+hcli batch create --name my-batch --key alice
+
+hcli token create-ft \
+  --token-name "Token A" --symbol "TA" \
+  --treasury alice --decimals 8 \
+  --initial-supply 1000 --supply-type FINITE --max-supply 10000 \
+  --admin-key alice --supply-key alice --name token-a \
+  --batch my-batch
+
+hcli token create-ft \
+  --token-name "Token B" --symbol "TB" \
+  --treasury alice --decimals 8 \
+  --initial-supply 500 --supply-type INFINITE \
+  --admin-key alice --supply-key alice --name token-b \
+  --batch my-batch
+
+hcli batch execute --name my-batch
+```
+
+**List batches**
+
+```sh
+hcli batch list
+```
+
+**Remove one queued transaction or drop the whole batch**
+
+```sh
+hcli batch delete --name my-batch --order 2
+hcli batch delete --name my-batch
+```
+
+## Full Command Reference
+
+<Accordion title="Batch Create">
+    Create a named batch and choose which key will sign the batch transaction when you run **`batch execute`**.
+
+    <ResponseField name="-n, --name" type="string" required>
+        Name or alias for the batch.
+    </ResponseField>
+
+    <ResponseField name="-k, --key" type="string">
+        Key used to sign batched transactions. Defaults to the operator when omitted. Accepts `{accountId}:{privateKey}`, `{ed25519|ecdsa}:private:{private-key}`, key reference, or account alias.
+    </ResponseField>
+
+    <ResponseField name="-m, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli batch create --name my-batch --key alice
+    ```
+</Accordion>
+
+<Accordion title="Batch Execute">
+    Sign and submit all transactions in the batch as one atomic batch transaction. The batch must already exist and contain at least one queued transaction. After a successful run, related plugins update local state (for example token or account hooks registered on this command).
+
+    <ResponseField name="-n, --name" type="string" required>
+        Name of the batch to execute.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli batch execute --name my-batch
+    ```
+</Accordion>
+
+<Accordion title="Batch List">
+    List all batches stored in CLI state (name, size, execution status).
+
+    **Example**
+
+    ```sh
+    hcli batch list
+    ```
+</Accordion>
+
+<Accordion title="Batch Delete">
+    Delete an entire batch, or remove a single queued transaction by its order index.
+
+    <ResponseField name="-n, --name" type="string" required>
+        Name of the batch.
+    </ResponseField>
+
+    <ResponseField name="-o, --order" type="int">
+        1-based order of the transaction to remove. If omitted, the whole batch is deleted.
+    </ResponseField>
+
+    **Examples**
+
+    ```sh
+    hcli batch delete --name my-batch --order 3
+    hcli batch delete --name my-batch
+    ```
+</Accordion>
+
+## Adding transactions to a batch (`-B` / `--batch`)
+
+The Batch plugin registers hooks that other commands use. When a command supports batching and you pass **`-B <name>`** or **`--batch <name>`** (same option), the CLI **does not** submit that transaction immediately. It serializes the signed inner transaction and appends it to the batch named `<name>`. Run **`hcli <plugin> <subcommand> --help`** on the command you care about. If batching is wired for that command, the help text includes **`-B` / `--batch`**.
+
+As of the current Hiero CLI manifests, batch hooks are registered on:
+
+- **Account:** `create`, `update`, `delete`
+- **HBAR:** `transfer`
+- **Topic:** `create`, `submit-message`, `update`, `delete`
+- **Token:** many HTS transaction subcommands under `token` (see `src/plugins/token/manifest.ts` for the full list). Examples include `create-ft`, `create-ft-from-file`, `create-nft`, `create-nft-from-file`, `associate`, `transfer-ft`, `transfer-nft`, and other operations that declare `batchify-set-batch-key` / `batchify-add-transaction`.
+
+**Rules and limits**
+
+- Create the batch with **`batch create`** before adding transactions.
+- A batch can hold at most **50** inner transactions (enforced in the batch hook implementation). Limits and atomic batch semantics on the network come from **[HIP-551: Batch transactions](https://github.com/hiero-ledger/hiero-improvement-proposals/blob/main/HIP/hip-551.md)** in the Hiero Improvement Proposals repository.
+- **`batch execute`** refuses to run if that batch name was already executed on the current network. Use **`batch list`** to inspect status and **`batch delete`** to remove a batch you no longer need (including freeing a name for reuse).
+
+<Note>
+#### **Operator key on `batch create`:**
+
+The **`--key` / `-k`** flag on **`batch create`** is **optional** in the CLI manifest. If you omit it, signing falls back to the **operator** key. Some older README text may say the key is required. Trust **`hcli batch create --help`** and this page.
+</Note>

--- a/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin.mdx
@@ -128,3 +128,7 @@ As of the current Hiero CLI manifests, batch hooks are registered on:
 
 The **`--key` / `-k`** flag on **`batch create`** is **optional** in the CLI manifest. If you omit it, signing falls back to the **operator** key. Some older README text may say the key is required. Trust **`hcli batch create --help`** and this page.
 </Note>
+
+## Related
+
+For **Hedera scheduled transactions** (`--scheduled` / `-X`) instead of queued batch execution, see the [Schedule plugin](/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin).

--- a/hedera/open-source-solutions/hiero-cli/plugins/config-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/config-plugin.mdx
@@ -22,8 +22,8 @@ title: "Config Plugin"
         Option name to set. Use `list` command to check what options could be set.
     </ResponseField>
 
-    <ResponseField name="-v, --value" type="(boolean|number|string)" required>
-        Value to set (boolean|number|string). Booleans: true/false.
+    <ResponseField name="-v, --value" type="string" required>
+        Value to set (boolean, number, or string as text). Booleans: true/false.
     </ResponseField>
 </Accordion>
 
@@ -52,8 +52,12 @@ The config plugin allows you to control global Hiero CLI behavior. Configuration
     - `debug`: Verbose output for troubleshooting
 </ResponseField>
 
-<ResponseField name="default_key_manager" type="string" default="local_encrypted" required>
-    Defines which key manager the CLI uses by default when creating or managing keys. Keep the default `local_encrypted` setting unless you are working in a controlled test environment.<br/>
+<ResponseField name="default_key_manager" type="string" default="local" required>
+    Defines which key manager the CLI uses by default when creating or managing keys.<br/>
     - `local`: Keys are stored locally in plaintext (not recommended for production).<br/>
     - `local_encrypted`: Keys are stored locally and encrypted (recommended).<br/>
+</ResponseField>
+
+<ResponseField name="skip_confirmations" type="boolean" default="false" required>
+    When true, the CLI skips interactive confirmation prompts where supported (use with care).
 </ResponseField>

--- a/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin.mdx
@@ -1,0 +1,208 @@
+---
+title: "Contract ERC-20 Plugin"
+---
+
+The **Contract ERC-20** plugin calls standard **EIP-20** methods on a contract already deployed on Hedera. Deploy or import the contract first with the [Contract plugin](/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin).
+
+## Most Used Commands
+
+**Read token metadata and an account balance**
+
+```sh
+hcli contract-erc20 name --contract my-token
+hcli contract-erc20 decimals --contract my-token
+hcli contract-erc20 balance-of --contract my-token --account alice
+```
+
+**Transfer and approve (state-changing, signed by the operator)**
+
+```sh
+hcli contract-erc20 transfer --contract my-token --to bob --value 1000000
+hcli contract-erc20 approve --contract my-token --spender bob --value 500000
+```
+
+## Full Command Reference
+
+Commands use the **`contract-erc20`** namespace (for example **`hcli contract-erc20 name`**). **`--contract` / `-c`** accepts a local alias, Hedera contract ID (`0.0.xxx`), or EVM address (`0x…`) where the manifest says so.
+
+<Accordion title="Contract ERC-20 Name">
+    Call **`name()`** on the ERC-20 contract (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 name --contract my-token
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Symbol">
+    Call **`symbol()`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 symbol --contract my-token
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Decimals">
+    Call **`decimals()`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 decimals --contract my-token
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Total-Supply">
+    Call **`totalSupply()`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 total-supply --contract my-token
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Balance-Of">
+    Call **`balanceOf(address)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-a, --account" type="string" required>
+        Account to query: alias, Hedera account ID, or EVM address.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 balance-of --contract my-token --account 0.0.123456
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Allowance">
+    Call **`allowance(owner, spender)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    <ResponseField name="-o, --owner" type="string" required>
+        Owner account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-s, --spender" type="string" required>
+        Spender account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 allowance --contract my-token --owner alice --spender bob
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Transfer">
+    Call **`transfer(to, value)`**. Submits a contract call transaction (operator signs).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Recipient: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-v, --value" type="number" required>
+        Amount passed to **`transfer`** as configured by the token (often smallest units—confirm against **`decimals`** for your contract).
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 transfer --contract my-token --to bob --value 1000000
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Transfer-From">
+    Call **`transferFrom(from, to, value)`**. Requires a sufficient allowance from **`from`** for the signing account (typically the operator). Submits a contract call transaction.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-f, --from" type="string" required>
+        Source account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Recipient: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-v, --value" type="number" required>
+        Amount for **`transferFrom`**.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 transfer-from --contract my-token --from alice --to bob --value 500000
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-20 Approve">
+    Call **`approve(spender, value)`**. Submits a contract call transaction.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-s, --spender" type="string" required>
+        Spender account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-v, --value" type="number" required>
+        Approved amount for **`approve`**.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc20 approve --contract my-token --spender bob --value 1000000
+    ```
+</Accordion>
+
+## Related
+
+NFT contract helpers live in the **`contract-erc721`** plugin. Until the docs page is added, see the [contract-erc721 README in the Hiero CLI repository](https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract-erc721/README.md).

--- a/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin.mdx
@@ -205,4 +205,4 @@ Commands use the **`contract-erc20`** namespace (for example **`hcli contract-er
 
 ## Related
 
-NFT contract helpers live in the **`contract-erc721`** plugin. Until the docs page is added, see the [contract-erc721 README in the Hiero CLI repository](https://github.com/hiero-ledger/hiero-cli/blob/main/src/plugins/contract-erc721/README.md).
+NFT contract helpers are documented on the [Contract ERC-721 plugin](/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin) page.

--- a/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/contract-erc721-plugin.mdx
@@ -1,0 +1,294 @@
+---
+title: "Contract ERC-721 Plugin"
+---
+
+The **Contract ERC-721** plugin calls standard **EIP-721** methods on an NFT collection contract deployed on Hedera. Deploy or import the contract first with the [Contract plugin](/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin). For fungible (ERC-20) calls, see the [Contract ERC-20 plugin](/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin).
+
+## Most Used Commands
+
+**Read collection metadata and token ownership**
+
+```sh
+hcli contract-erc721 name --contract my-nft
+hcli contract-erc721 owner-of --contract my-nft --token-id 1
+hcli contract-erc721 token-uri --contract my-nft --token-id 1
+```
+
+**Approve and transfer a specific token**
+
+```sh
+hcli contract-erc721 approve --contract my-nft --to bob --token-id 1
+hcli contract-erc721 safe-transfer-from --contract my-nft --from alice --to bob --token-id 1
+```
+
+## Full Command Reference
+
+Commands use the **`contract-erc721`** namespace (for example **`hcli contract-erc721 name`**). **`--contract` / `-c`** accepts a local alias, Hedera contract ID (`0.0.xxx`), or EVM address (`0x…`) where the manifest allows it.
+
+<Accordion title="Contract ERC-721 Name">
+    Call **`name()`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 name --contract my-nft
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Symbol">
+    Call **`symbol()`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 symbol --contract my-nft
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Balance-Of">
+    Call **`balanceOf(address)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    <ResponseField name="-o, --owner" type="string" required>
+        Owner account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 balance-of --contract my-nft --owner alice
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Owner-Of">
+    Call **`ownerOf(uint256 tokenId)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID (`uint256`).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 owner-of --contract my-nft --token-id 1
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Get-Approved">
+    Call **`getApproved(uint256 tokenId)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID to query.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 get-approved --contract my-nft --token-id 1
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Is-Approved-For-All">
+    Call **`isApprovedForAll(address owner, address operator)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-o, --owner" type="string" required>
+        Owner account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-p, --operator" type="string" required>
+        Operator account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 is-approved-for-all --contract my-nft --owner alice --operator bob
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Token-URI">
+    Call **`tokenURI(uint256 tokenId)`** (read-only).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID or local alias.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID to query.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 token-uri --contract my-nft --token-id 1
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Approve">
+    Call **`approve(address to, uint256 tokenId)`**. State-changing (operator signs).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Address approved to transfer the token: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID to approve.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 approve --contract my-nft --to bob --token-id 1
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Set-Approval-For-All">
+    Call **`setApprovalForAll(address operator, bool approved)`**. State-changing.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-o, --operator" type="string" required>
+        Operator account: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-a, --approved" type="string" required>
+        Must be the string **`true`** or **`false`**.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 set-approval-for-all --contract my-nft --operator bob --approved true
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Safe-Transfer-From">
+    Call **`safeTransferFrom`** (with or without the extra **`bytes`** argument). State-changing.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-f, --from" type="string" required>
+        Current owner: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        New owner: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID to transfer.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    <ResponseField name="-d, --data" type="string">
+        Optional data payload for the 4-argument **`safeTransferFrom`** overload.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 safe-transfer-from --contract my-nft --from alice --to bob --token-id 1
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Transfer-From">
+    Call **`transferFrom(address from, address to, uint256 tokenId)`**. State-changing.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-f, --from" type="string" required>
+        Current owner: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Recipient: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID to transfer.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 transfer-from --contract my-nft --from alice --to bob --token-id 1
+    ```
+</Accordion>
+
+<Accordion title="Contract ERC-721 Mint">
+    Calls a **custom** **`mint(address to, uint256 tokenId)`** style entry point (experimental). The manifest marks this command as experimental and assumes a contract that exposes a compatible **`mint`** used for testing.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Smart contract ID, alias, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Recipient of the minted token: alias, account ID, or EVM address.
+    </ResponseField>
+
+    <ResponseField name="-T, --token-id" type="number" required>
+        Token ID to mint.
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="100000">
+        Gas for the contract call.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli contract-erc721 mint --contract my-nft --to alice --token-id 42
+    ```
+</Accordion>
+
+## Related
+
+Fungible token helpers: [Contract ERC-20 plugin](/hedera/open-source-solutions/hiero-cli/plugins/contract-erc20-plugin). Deploy and import: [Contract plugin](/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin).

--- a/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/contract-plugin.mdx
@@ -1,0 +1,187 @@
+---
+title: "Contract Plugin"
+---
+
+## Most Used Commands
+
+**Deploy from a Solidity file**
+
+```sh
+hcli contract create \
+  --name my-contract \
+  --file ./MyContract.sol \
+  --admin-key alice
+```
+
+**Import an existing on-chain contract into local state**
+
+```sh
+hcli contract import --contract 0.0.123456 --name my-alias
+```
+
+**List saved contracts**
+
+```sh
+hcli contract list
+```
+
+**Delete on Hedera (beneficiary required) or drop local state only**
+
+```sh
+hcli contract delete --contract my-alias --transfer-id 0.0.7890
+hcli contract delete --contract 0.0.123456 --state-only
+```
+
+<Note>
+#### **Create: `--file` vs `--default`**
+
+You must supply **`--file`** (path to a `.sol` file) **or** **`--default`** (`erc20` or `erc721` built-in template). They are mutually exclusive.
+</Note>
+
+## Full Command Reference
+
+<Accordion title="Contract Create">
+    Compile a Solidity source (or use a built-in template), deploy the contract to the current network, and run verification where the CLI supports it.
+
+    <ResponseField name="-n, --name" type="string" required>
+        Smart contract name or alias stored in CLI state.
+    </ResponseField>
+
+    <ResponseField name="-f, --file" type="string">
+        Path to a Solidity file (absolute or relative). Use with **`--base-path`** when imports need a root directory.
+    </ResponseField>
+
+    <ResponseField name="-d, --default" type="string(erc20|erc721)">
+        Use a built-in template instead of **`--file`**. Mutually exclusive with **`--file`**.
+    </ResponseField>
+
+    <ResponseField name="-b, --base-path" type="string">
+        Base directory for resolving the Solidity file. Defaults to the current directory when using **`--file`** (see CLI README for **`--default`** behavior).
+    </ResponseField>
+
+    <ResponseField name="-g, --gas" type="number" default="2000000">
+        Gas limit for contract creation.
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        Admin key credential(s) for the new contract. Pass multiple times for **KeyList** / **ThresholdKey** style setups. See **`hcli contract create --help`** for accepted formats.
+    </ResponseField>
+
+    <ResponseField name="-A, --admin-key-threshold" type="int">
+        M-of-N: how many of the **`--admin-key`** values must sign the create flow. Only applies when multiple **`--admin-key`** entries are provided.
+    </ResponseField>
+
+    <ResponseField name="-m, --memo" type="string">
+        Contract memo.
+    </ResponseField>
+
+    <ResponseField name="-v, --solidity-version" type="string">
+        Solidity compiler version to use for compilation.
+    </ResponseField>
+
+    <ResponseField name="-c, --constructor-parameter" type="string (repeatable)">
+        Constructor argument values, in order. Repeat the flag once per argument.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting).
+    </ResponseField>
+
+    <ResponseField name="-i, --initial-balance" type="string">
+        Initial HBAR balance for the contract. Examples: `100` (HBAR) or `100t` (tinybars).
+    </ResponseField>
+
+    <ResponseField name="-r, --auto-renew-period" type="string">
+        Auto-renew period: seconds as an integer, or with suffix `s`, `m`, `h`, or `d` (e.g. `500`, `500s`, `50m`, `2h`, `30d`).
+    </ResponseField>
+
+    <ResponseField name="-R, --auto-renew-account-id" type="string">
+        Account ID (`0.0.xxx`) that pays for contract auto-renewal.
+    </ResponseField>
+
+    <ResponseField name="-t, --max-automatic-token-associations" type="int">
+        Maximum automatic token associations (`-1` for unlimited, `0` to disable).
+    </ResponseField>
+
+    <ResponseField name="-s, --staked-account-id" type="string">
+        Account ID (`0.0.xxx`) to stake the contract to. Mutually exclusive with **`--staked-node-id`**.
+    </ResponseField>
+
+    <ResponseField name="-o, --staked-node-id" type="number">
+        Node ID to stake the contract to. Mutually exclusive with **`--staked-account-id`**.
+    </ResponseField>
+
+    <ResponseField name="-D, --decline-staking-reward" type="boolean">
+        Whether to decline staking rewards for this contract.
+    </ResponseField>
+
+    **Examples**
+
+    ```sh
+    hcli contract create --name my-token --default erc20
+    hcli contract create --name app --file ./App.sol --admin-key alice --gas 3000000
+    ```
+</Accordion>
+
+<Accordion title="Contract List">
+    List smart contracts stored in CLI state (including metadata such as network and verification flags where available).
+
+    **Example**
+
+    ```sh
+    hcli contract list
+    ```
+</Accordion>
+
+<Accordion title="Contract Import">
+    Import an existing contract from Hedera by **`0.0.xxx`** ID or **`0x…`** EVM address. The CLI reads contract info from the mirror node and stores admin key metadata in local state for later operations.
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Contract ID (`0.0.xxx`) or EVM address (`0x…`).
+    </ResponseField>
+
+    <ResponseField name="-n, --name" type="string">
+        Optional local alias for the imported contract.
+    </ResponseField>
+</Accordion>
+
+<Accordion title="Contract Delete">
+    By default, submits a **`ContractDeleteTransaction`** on Hedera and then removes the contract from local state. With **`--state-only`**, only local state is cleared (no network transaction).
+
+    <ResponseField name="-c, --contract" type="string" required>
+        Contract ID (`0.0.xxx`) or local alias.
+    </ResponseField>
+
+    <ResponseField name="-s, --state-only">
+        Remove from local CLI state only. No network delete.
+    </ResponseField>
+
+    <ResponseField name="-t, --transfer-id" type="string">
+        Account (ID or alias) that receives remaining HBAR after an on-chain delete. For a network delete, supply exactly one of **`--transfer-id`** or **`--transfer-contract-id`**. Do not combine with **`--state-only`**.
+    </ResponseField>
+
+    <ResponseField name="-r, --transfer-contract-id" type="string">
+        Contract (ID or alias) that receives remaining HBAR. For a network delete, supply exactly one of **`--transfer-id`** or **`--transfer-contract-id`** (never both).
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        Optional signing credential(s) for the network delete. Not allowed with **`--state-only`**. If omitted on a network delete, the CLI derives required admin keys from the mirror node and matches KMS keys (including M-of-N). Pass multiple times when several keys must sign.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager used when resolving **`--admin-key`** (defaults to config).
+    </ResponseField>
+
+    **Examples**
+
+    ```sh
+    hcli contract delete --contract my-alias --transfer-id 0.0.5678
+    hcli contract delete --contract 0.0.123456 --state-only
+    ```
+
+    This command uses **`requireConfirmation`**. In non-interactive environments, use the root **`--confirm`** flag (see [Overview](/hedera/open-source-solutions/hiero-cli/overview) → Global Flags) so the CLI does not block on the prompt.
+</Accordion>
+
+## Related plugins
+
+ERC-20 and ERC-721 helper plugins focus on **calling** deployed contracts. This page covers **compile**, **deploy**, **import**, **list**, and **delete** for Solidity sources and built-in **`erc20`** / **`erc721`** templates.

--- a/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/hbar-plugin.mdx
@@ -7,7 +7,7 @@ title: "HBAR Plugin"
 <Accordion title="HBAR Transfer">
     Transfer HBAR (tinybars) from one account to another.
 
-    <ResponseField name="-a, --amount" type="int" required>
+    <ResponseField name="-a, --amount" type="string" required>
         Amount to transfer. Default: display units.<br/>
         Add `t` for base units. Example: "1" = 1 HBAR, "100t" = 100 tinybar
     </ResponseField>
@@ -16,9 +16,8 @@ title: "HBAR Plugin"
         Account ID or name to transfer to
     </ResponseField>
 
-    <ResponseField name="-f, --from" type="string" required>
-        AccountID:privateKey pair, AccountID:keyType:privateKey format, or account name to transfer from (defaults to operator).<br/>
-        Key type can be "ecdsa" or "ed25519" (defaults to ecdsa if not specified).
+    <ResponseField name="-f, --from" type="string">
+        Account to transfer from: `accountId:privateKey` pair, key reference, or account name. Defaults to the operator.
     </ResponseField>
 
     <ResponseField name="-m, --memo" type="string">

--- a/hedera/open-source-solutions/hiero-cli/plugins/network-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/network-plugin.mdx
@@ -11,29 +11,21 @@ title: "Network Plugin"
 <Accordion title="Network Use">
     Switch the active network to the specified network name.
 
-    <ResponseField name="-N, --network" type="string" required>
+    <ResponseField name="-g, --global" type="string" required>
         Network name (testnet, mainnet, previewnet, localnet)
     </ResponseField>
 </Accordion>
 
 <Accordion title="Network Get-Operator">
-    Get operator credentials for a specific network.
-
-    <ResponseField name="-N, --network" type="string">
-        Target network (defaults to current network)
-    </ResponseField>
+    Get operator credentials for the **current** network. The active network is whichever you set with `network use` or the global `-N` / `--network` flag on the root command.
 </Accordion>
 
 <Accordion title="Network Set-Operator" defaultOpen="true">
-    Set operator credentials for signing transactions on a specific network.<br/><br/>
+    Set operator credentials for signing transactions on the **current** network (see `network use` or root `-N` / `--network`).<br/><br/>
     **⚠️ Use this command to set the operator to avoid triggering the setup wizard asking you to set up an operator account. This is important when using the Hiero CLI in a CI/CD environment.**
 
     <ResponseField name="-o, --operator" type="string" required>
-        Operator credentials: name or `account-id:private-key pair`.
-    </ResponseField>
-
-    <ResponseField name="-N, --network" type="string">
-        Target network (defaults to current network).
+        Operator credentials: name or `account-id:private-key` pair, key reference, or account alias.
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">

--- a/hedera/open-source-solutions/hiero-cli/plugins/plugin-management-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/plugin-management-plugin.mdx
@@ -6,10 +6,14 @@ title: "Plugin Management Plugin"
 ## Full Command Reference
 
 <Accordion title="Plugin Management Add">
-    Add a new plugin to the plugin-management state and enable it.
+    Add a new plugin to the plugin-management state and enable it. Provide **`--path`** for a custom plugin directory, or **`--name`** for a built-in plugin name (resolved under the CLI plugins directory). One of the two is required.
 
-    <ResponseField name="-p, --path" type="string" required>
+    <ResponseField name="-p, --path" type="string">
         Filesystem path to the plugin directory containing `manifest.js`
+    </ResponseField>
+
+    <ResponseField name="-n, --name" type="string">
+        Name of a default plugin to add (for example `account`, `token`). Use `--path` for custom plugins.
     </ResponseField>
 </Accordion>
 
@@ -39,4 +43,16 @@ title: "Plugin Management Plugin"
 
 <Accordion title="Plugin Management List">
     Show all loaded plugins.
+</Accordion>
+
+<Accordion title="Plugin Management Reset">
+    Clear plugin-management state. Custom plugins will be removed. Prompts for confirmation unless confirmations are skipped globally.
+</Accordion>
+
+<Accordion title="Plugin Management Info">
+    Show detailed information about a specific plugin.
+
+    <ResponseField name="-n, --name" type="string" required>
+        Name of the plugin for information display
+    </ResponseField>
 </Accordion>

--- a/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/schedule-plugin.mdx
@@ -1,0 +1,156 @@
+---
+title: "Schedule Plugin"
+---
+
+## Most Used Commands
+
+**Register a schedule, submit a transfer as `ScheduleCreate`, then sign and verify**
+
+```sh
+hcli schedule create --name team-payout --admin-key alice --expiration "2026-12-31T23:59:59.000Z"
+
+hcli token transfer-ft \
+  --token MYTOKEN \
+  --from alice \
+  --to bob \
+  --amount 10 \
+  --scheduled team-payout
+
+hcli schedule sign --schedule team-payout --key bob
+
+hcli schedule verify --name team-payout
+```
+
+<Note>
+#### **Batch vs schedule**
+
+The **Batch** plugin queues signed inner transactions for a later atomic **`batch execute`**. The **Schedule** plugin submits a **Hedera schedule** so execution depends on signatures and mirror-visible schedule state. See the [Batch plugin](/hedera/open-source-solutions/hiero-cli/plugins/batch-plugin) page for **`--batch` / `-B`**. Avoid combining flags in ways your command’s help does not describe.
+</Note>
+
+## Full Command Reference
+
+<Accordion title="Schedule Create">
+    Register a **named** schedule in local CLI state (per network). That name is what you pass to **`--scheduled` / `-X`** on supported commands so the inner transaction is wrapped in a Hedera **`ScheduleCreateTransaction`** instead of executing immediately.
+
+    <ResponseField name="-n, --name" type="string" required>
+        Local name of the schedule record.
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string">
+        Admin key for managing the schedule on chain (resolved to a key the CLI can use).
+    </ResponseField>
+
+    <ResponseField name="-p, --payer-account" type="string">
+        Payer for the scheduled transaction. Must resolve to an account ID with a private key. Defaults to the operator.
+    </ResponseField>
+
+    <ResponseField name="-m, --memo" type="string">
+        Public schedule memo (max 100 bytes).
+    </ResponseField>
+
+    <ResponseField name="-e, --expiration" type="string">
+        Expiration time in ISO 8601. Must be at most 62 days from now.
+    </ResponseField>
+
+    <ResponseField name="-w, --wait-for-expiry" type="boolean">
+        When set, the schedule runs at expiration time instead of as soon as required signatures are collected.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli schedule create --name my-schedule --admin-key alice --memo "Q1 payout"
+    ```
+</Accordion>
+
+<Accordion title="Schedule Sign">
+    Submit a **`ScheduleSignTransaction`** to add a signature to an existing schedule. **`--schedule`** accepts either a **`0.0.x`** schedule entity ID or the local name from **`schedule create`**.
+
+    <ResponseField name="-s, --schedule" type="string" required>
+        Schedule ID (`0.0.x`) or local schedule name.
+    </ResponseField>
+
+    <ResponseField name="-k, --key" type="string" required>
+        Key material whose signature is added. Must resolve to a private key the CLI can sign with.
+    </ResponseField>
+
+    <ResponseField name="-K, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli schedule sign --schedule my-schedule --key carol
+    ```
+</Accordion>
+
+<Accordion title="Schedule Delete">
+    Remove the schedule on chain when applicable and align local state. An admin key is required on chain. If **`--admin-key`** is omitted, the CLI uses the admin key stored on the local schedule record when available.
+
+    <ResponseField name="-s, --schedule" type="string" required>
+        Schedule ID (`0.0.x`) or local schedule name.
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string">
+        Admin key used to sign the delete. Optional if the stored record supplies one.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli schedule delete --schedule my-schedule --admin-key alice
+    ```
+</Accordion>
+
+<Accordion title="Schedule Verify">
+    Query the Mirror Node to see whether a schedule has executed and refresh local flags. Provide **either** a local **`--name`** **or** a **`--schedule-id`** (validation requires at least one).
+
+    <ResponseField name="-n, --name" type="string">
+        Local name of the schedule record.
+    </ResponseField>
+
+    <ResponseField name="-s, --schedule-id" type="string">
+        Schedule entity ID (`0.0.x`).
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: `local` or `local_encrypted` (defaults to config setting).
+    </ResponseField>
+
+    **Examples**
+
+    ```sh
+    hcli schedule verify --name my-schedule
+    hcli schedule verify --schedule-id 0.0.1234567
+    ```
+</Accordion>
+
+## Scheduling inner transactions (`-X` / `--scheduled`)
+
+The Schedule plugin registers the **`scheduled`** hook. Commands that opt into this hook accept **`-X <name>`** or **`--scheduled <name>`**, where `<name>` matches a record from **`schedule create`**. When set, the hook builds and submits a **`ScheduleCreateTransaction`** around the inner transaction, stores the returned schedule ID on the record, and stops the normal “execute immediately” path for that invocation.
+
+If **`--scheduled`** is omitted, the hook does nothing and the command behaves as usual.
+
+As of the current Hiero CLI manifests, the hook is registered on:
+
+- **Account:** `create`, `update`
+- **HBAR:** `transfer`
+- **Topic:** `create`, `submit-message`
+- **Token:** `burn-ft`, `burn-nft`, `mint-ft`, `mint-nft`, `transfer-ft`, `transfer-nft`, `cancel-airdrop`, `create-ft`, `create-nft`, `associate`, `create-ft-from-file`, `create-nft-from-file`, `freeze`, `unfreeze`
+
+Use **`hcli <plugin> <subcommand> --help`** to confirm that **`--scheduled` / `-X`** appears for the command you are running.
+
+<Note>
+#### **Reuse and state**
+
+The hook rejects scheduling when the local record is already marked as having an on-chain schedule for that flow (`Transaction is already scheduled`). Plan names and cleanup (`schedule delete`, `schedule verify`) accordingly.
+</Note>

--- a/hedera/open-source-solutions/hiero-cli/plugins/token-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/token-plugin.mdx
@@ -4,16 +4,17 @@ title: "Token Plugin"
 
 ## Most Used Commands
 
-**Create a new token with treasy and admin key set to alias Alice**
+**Create a new fungible token with treasury and admin key set to alias Alice**
 
 ```sh
-hcli token create \
+hcli token create-ft \
   --token-name "My Token" \
   --symbol "MTK" \
   --treasury alice \
   --decimals 2 \
   --initial-supply 1000 \
   --supply-type FINITE \
+  --max-supply 10000 \
   --admin-key alice \
   --name mytoken-alias
 ```
@@ -26,47 +27,143 @@ hcli token associate \
   --account bob
 ```
 
+**Transfer fungible tokens**
+
+```sh
+hcli token transfer-ft \
+  --token mytoken-alias \
+  --to bob \
+  --amount 10
+```
+
+**Create an NFT collection, mint one serial, transfer it**
+
+```sh
+hcli token create-nft \
+  --token-name "My Collection" \
+  --symbol "MCOL" \
+  --treasury alice \
+  --admin-key alice \
+  --supply-key alice \
+  --name my-nft-alias
+
+hcli token mint-nft \
+  --token my-nft-alias \
+  --metadata "ipfs://bafyExample/metadata-1.json"
+
+hcli token transfer-nft \
+  --token my-nft-alias \
+  --to bob \
+  --serials 1
+```
+
 ## Full Command Reference
 
-If you want to create a complex token with many keys, custom fees, and other options, take a look at the [below guide](#guide:-token-create-from-file-specification) for creating tokens from a specification file using the `token create-from-file` command.
+The token plugin includes many subcommands (NFTs, airdrops, mint, burn, freeze, and more). The sections below cover common **FT** and **NFT** flows. For the full command list and flags, run `hcli token --help`, then `hcli token` with your subcommand and `--help`.
 
-<Accordion title="Token Create">
+For repeatable creation from JSON, use **`token create-ft-from-file`** or **`token create-nft-from-file`** and the [guide below](#guide-token-create-from-file-specification).
+
+<Accordion title="Token Create-FT">
     Create a new fungible token with specified properties.
 
-    <ResponseField name="-N, --token-name" type="string" required>
-        Token name.
+    <ResponseField name="-T, --token-name" type="string" required>
+        Fungible token name.
     </ResponseField>
 
-    <ResponseField name="-s, --symbol" type="string" required>
-        Token symbol.
+    <ResponseField name="-Y, --symbol" type="string" required>
+        Fungible token symbol.
     </ResponseField>
 
-    <ResponseField name="-t, --treasury" type="string" required>
-        Treasury account: either an alias or `treasury-id:treasury-key` pair.
+    <ResponseField name="-t, --treasury" type="string">
+        Treasury account: `{accountId}:{privateKey}` pair, key reference, or account alias. Defaults to the operator.
     </ResponseField>
 
     <ResponseField name="-d, --decimals" type="int" default="0">
-        Decimals for the token. Default: 0.
+        Decimals for the fungible token. Default: 0.
     </ResponseField>
 
-    <ResponseField name="-i, --initial-supply" type="int">
-        Initial supply amount. Default: display units (with decimals applied). Append "t" for raw base units (e.g., "1000t").
+    <ResponseField name="-i, --initial-supply" type="string">
+        Initial supply amount. Default: `1000000` in display units (with decimals applied). Append `t` for raw base units (e.g., `1000t`).
     </ResponseField>
 
-    <ResponseField name="-S, --supply-type" type="int" default="INFINITE">
-        Set supply type: `INFINITE` (default) or `FINITE`.
+    <ResponseField name="-S, --supply-type" type="string" default="INFINITE">
+        Supply type: `INFINITE` (default) or `FINITE`.
     </ResponseField>
 
-    <ResponseField name="-m, --max-supply" type="int">
-        Maximum supply of the token to bet set upon creation. **This option is required if you set supply type to `FINITE`.**
+    <ResponseField name="-m, --max-supply" type="string">
+        Maximum supply at creation (display units, or append `t` for raw base units). Use with `FINITE` supply type.
     </ResponseField>
 
-    <ResponseField name="-a, --admin-key" type="string">
-        Admin key to be set for the token upon creation. If option not set then the operator key is passed as admin key.
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        Optional admin key. Can be `{accountId}:{privateKey}` pair, private key in `{ed25519|ecdsa}:private:{private-key}` format, key reference, or account alias. Omit for a token without an admin key.
+    </ResponseField>
+
+    <ResponseField name="-A, --admin-key-threshold" type="int">
+        M-of-N: number of admin keys required to sign (only when multiple `--admin-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-s, --supply-key" type="string (repeatable)">
+        Supply key(s). Same key formats as other repeatable token keys.
+    </ResponseField>
+
+    <ResponseField name="-L, --supply-key-threshold" type="int">
+        M-of-N for supply keys (only when multiple `--supply-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-f, --freeze-key" type="string (repeatable)">
+        Optional freeze key(s).
+    </ResponseField>
+
+    <ResponseField name="-Z, --freeze-key-threshold" type="int">
+        M-of-N for freeze keys (only when multiple `--freeze-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-F, --freeze-default" type="boolean" default="false">
+        When true and a freeze key is set, new token associations are frozen by default. Ignored without a freeze key (a warning is logged).
+    </ResponseField>
+
+    <ResponseField name="-w, --wipe-key" type="string (repeatable)">
+        Optional wipe key(s).
+    </ResponseField>
+
+    <ResponseField name="-W, --wipe-key-threshold" type="int">
+        M-of-N for wipe keys (only when multiple `--wipe-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-y, --kyc-key" type="string (repeatable)">
+        Optional KYC key(s).
+    </ResponseField>
+
+    <ResponseField name="-H, --kyc-key-threshold" type="int">
+        M-of-N for KYC keys (only when multiple `--kyc-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-p, --pause-key" type="string (repeatable)">
+        Optional pause key(s).
+    </ResponseField>
+
+    <ResponseField name="-U, --pause-key-threshold" type="int">
+        M-of-N for pause keys (only when multiple `--pause-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-e, --fee-schedule-key" type="string (repeatable)">
+        Optional fee schedule key(s).
+    </ResponseField>
+
+    <ResponseField name="-E, --fee-schedule-key-threshold" type="int">
+        M-of-N for fee schedule keys (only when multiple `--fee-schedule-key` values are set).
+    </ResponseField>
+
+    <ResponseField name="-D, --metadata-key" type="string (repeatable)">
+        Optional metadata key(s).
+    </ResponseField>
+
+    <ResponseField name="-O, --metadata-key-threshold" type="int">
+        M-of-N for metadata keys (only when multiple `--metadata-key` values are set).
     </ResponseField>
 
     <ResponseField name="-n, --name" type="string">
-        Optional name to register for the token.
+        Optional name to register for the fungible token (local alias).
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
@@ -74,21 +171,121 @@ If you want to create a complex token with many keys, custom fees, and other opt
     </ResponseField>
 
     <ResponseField name="-M, --memo" type="string">
-        Optional memo for the token (max 100 characters).
+        Optional memo for the fungible token (max 100 characters).
     </ResponseField>
+
+    <ResponseField name="-R, --auto-renew-period" type="string">
+        Auto-renew period: seconds as integer, or with suffix s/m/h/d (e.g. 500, 500s, 50m, 2h, 1d). Requires `--auto-renew-account`.
+    </ResponseField>
+
+    <ResponseField name="-r, --auto-renew-account" type="string">
+        Account that pays auto-renewal (account id, alias, or key reference). Required when `--auto-renew-period` is set.
+    </ResponseField>
+
+    <ResponseField name="-x, --expiration-time" type="string">
+        Absolute token expiration as ISO 8601 datetime. Ignored when `--auto-renew-period` and `--auto-renew-account` are set.
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token create-ft \
+      --token-name "My Token" \
+      --symbol "MTK" \
+      --treasury alice \
+      --decimals 2 \
+      --initial-supply 1000 \
+      --name my-ft-alias
+    ```
 </Accordion>
 
-<Accordion title="Token Create-From-File">
-    Create a new token from a JSON file definition with advanced features. See the full guide below.<br/>
-    Example: `hcli token create-from-file --file ~/projects/token.json`
-   
-    <ResponseField name="-f, --file" type="string" required>
-        Token definition file path (absolute or relative) to a JSON file.
+<Accordion title="Token Create-NFT">
+    Create a new non-fungible token (NFT collection). Use **`token mint-nft`** after creation to mint serials. See `hcli token create-nft --help` for all key types and thresholds.
+
+    <ResponseField name="-T, --token-name" type="string" required>
+        Token name.
+    </ResponseField>
+
+    <ResponseField name="-Y, --symbol" type="string" required>
+        Token symbol.
+    </ResponseField>
+
+    <ResponseField name="-t, --treasury" type="string">
+        Treasury account. Defaults to the operator.
+    </ResponseField>
+
+    <ResponseField name="-S, --supply-type" type="string" default="INFINITE">
+        `INFINITE` or `FINITE`. With `FINITE`, set `--max-supply`.
+    </ResponseField>
+
+    <ResponseField name="-m, --max-supply" type="string">
+        Max supply (display units, or append `t` for base units). Required when supply type is `FINITE`.
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        Admin key(s). Defaults to operator key when omitted (see CLI help).
+    </ResponseField>
+
+    <ResponseField name="-s, --supply-key" type="string (repeatable)">
+        Supply key(s) for minting NFT serials.
+    </ResponseField>
+
+    <ResponseField name="-n, --name" type="string">
+        Optional local alias for the token.
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
         Key manager to use: local or local_encrypted (defaults to config setting).
     </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token create-nft \
+      --token-name "Collectible" \
+      --symbol "COLL" \
+      --treasury alice \
+      --admin-key alice \
+      --supply-key alice \
+      --name coll-alias
+    ```
+</Accordion>
+
+<Accordion title="Token Create-FT-From-File">
+    Create a new fungible token from a JSON file definition with advanced features. See the full guide below.<br/>
+    Example: `hcli token create-ft-from-file --file ~/projects/token.json`
+   
+    <ResponseField name="-f, --file" type="string" required>
+        Fungible token definition file path (absolute or relative) to a JSON file.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: local or local_encrypted (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token create-ft-from-file --file ./token-ft.json
+    ```
+</Accordion>
+
+<Accordion title="Token Create-NFT-From-File">
+    Create a new NFT collection from a JSON definition. Schema matches the NFT file format in the [guide](#nft-definition-file-quickstart).
+
+    <ResponseField name="-f, --file" type="string" required>
+        NFT token definition file path (absolute or relative) to a JSON file.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: local or local_encrypted (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token create-nft-from-file --file ./token-nft.json
+    ```
 </Accordion>
 
 <Accordion title="Token Associate">
@@ -99,48 +296,132 @@ If you want to create a complex token with many keys, custom fees, and other opt
     </ResponseField>
 
     <ResponseField name="-a, --account" type="string" required>
-        Account: either an alias or `account-id:account-key` pair to associate with the token.
+        Account to associate: `{accountId}:{privateKey}` pair, key reference, or account alias.
     </ResponseField>
 
    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
         Key manager to use: local or local_encrypted (defaults to config setting).
     </ResponseField>
+
+    **Examples**
+
+    Fungible or NFT token alias:
+
+    ```sh
+    hcli token associate --token my-ft-alias --account bob
+    ```
+
+    ```sh
+    hcli token associate --token coll-alias --account bob
+    ```
 </Accordion>
 
-<Accordion title="Token Transfer">
-    Transfer a fungible token from one account to another.
+<Accordion title="Token Mint-NFT">
+    Mint a new NFT serial on an existing collection. Metadata must be at most 100 bytes.
 
     <ResponseField name="-T, --token" type="string" required>
-        Token: either a token alias or token-id.
+        NFT token: alias or token ID.
     </ResponseField>
 
-    <ResponseField name="-t, --to" type="string" required>
-        Destination account: either an alias or account-id.
+    <ResponseField name="-m, --metadata" type="string" required>
+        NFT metadata string (max 100 bytes), often a URI or short label.
     </ResponseField>
 
-    <ResponseField name="-f, --from" type="string" required>
-        Source account: either a stored alias or `account-id:private-key` or `account-id:key-type:private-key pair`.
-    </ResponseField>
-
-    <ResponseField name="-a, --amount" type="int" required>
-        Amount to transfer. Default: display units (with decimals applied). Append "t" for raw base units (e.g., "100t").
+    <ResponseField name="-s, --supply-key" type="string (repeatable)">
+        Supply key credential(s). Omit when the CLI can resolve signing keys from the key manager.
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
         Key manager to use: local or local_encrypted (defaults to config setting).
     </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token mint-nft \
+      --token coll-alias \
+      --metadata "ipfs://bafyExample/1.json"
+    ```
+</Accordion>
+
+<Accordion title="Token Transfer-FT">
+    Transfer a fungible token from one account to another.
+
+    <ResponseField name="-T, --token" type="string" required>
+        Fungible token: either a token alias or token-id.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Destination account: account ID or alias.
+    </ResponseField>
+
+    <ResponseField name="-f, --from" type="string">
+        Account to transfer from: `{accountId}:{privateKey}` pair, key reference, or account alias. Defaults to the operator.
+    </ResponseField>
+
+    <ResponseField name="-a, --amount" type="string" required>
+        Amount to transfer. Default: display units (with decimals applied). Append `t` for raw base units (e.g., `100t`).
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: local or local_encrypted (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token transfer-ft \
+      --token my-ft-alias \
+      --to bob \
+      --amount 25
+    ```
+</Accordion>
+
+<Accordion title="Token Transfer-NFT">
+    Transfer one or more NFT serials to another account.
+
+    <ResponseField name="-T, --token" type="string" required>
+        NFT token: alias or token ID.
+    </ResponseField>
+
+    <ResponseField name="-t, --to" type="string" required>
+        Destination account ID or alias.
+    </ResponseField>
+
+    <ResponseField name="-f, --from" type="string">
+        Source account. Defaults to the operator.
+    </ResponseField>
+
+    <ResponseField name="-s, --serials" type="string" required>
+        Comma-separated serial numbers (e.g. `1,2,3`).
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: local or local_encrypted (defaults to config setting).
+    </ResponseField>
+
+    **Example**
+
+    ```sh
+    hcli token transfer-nft \
+      --token coll-alias \
+      --to bob \
+      --serials 1
+    ```
 </Accordion>
 
 <Accordion title="Token List">
-    List all tokens stored in state for the current network or a specified network.
+    List all tokens (FT and NFT) stored in state for all networks.
 
-    <ResponseField name="-k, --keys">
+    <ResponseField name="-k, --keys" type="boolean">
         Show token key information (admin, supply, wipe, etc.).
     </ResponseField>
 
-    <ResponseField name="-N, --network" type="string">
-        Filter tokens by network (defaults to current active network).
-    </ResponseField>
+    **Example**
+
+    ```sh
+    hcli token list --keys
+    ```
 </Accordion>
 
 ## Guide: Token Create From File (Specification)
@@ -149,7 +430,10 @@ Create a token by defining its configuration in a JSON file. This is the recomme
 
 ### What it does
 
-`token create-from-file` reads a JSON file that matches a supported schema and creates a token on the selected network.
+- **`token create-ft-from-file`** reads a JSON file that matches the **fungible** schema and creates an FT on the selected network.
+- **`token create-nft-from-file`** reads a JSON file that matches the **NFT** schema and creates an NFT collection on the selected network.
+
+### Fungible token (FT) file
 
 You can define:
 - token metadata (name, symbol, decimals, memo)
@@ -158,7 +442,7 @@ You can define:
 - optional token associations
 - optional custom fees
 
-### Quickstart
+#### Quickstart (FT)
 
 Create a `token.json` file and add a JSON specification. Here's a basic example that both uses the full key format for the `treasuryKey` and the alias format for the `adminKey`.
 
@@ -174,9 +458,9 @@ Create a `token.json` file and add a JSON specification. Here's a basic example 
 }
 ```
 
-You can create a toke from this specification by running the following command: `hcli token create-from-file --file ./token.json`
+You can create a token from this specification by running the following command: `hcli token create-ft-from-file --file ./token.json`
 
-### Full breakdown
+#### Full breakdown (FT)
 
 Here's a full breakdown of all the options you can use:
 
@@ -209,3 +493,29 @@ Here's a full breakdown of all the options you can use:
   ]
 }
 ```
+
+### NFT definition file quickstart
+
+NFT JSON files use a different schema than FT files. There is no `decimals` or `initialSupply`. You must provide at least one **`adminKey`** and one **`supplyKey`** (each can be a single string or an array of key strings). For **`supplyType`** `finite`, set **`maxSupply`**. For **`infinite`**, do not include `maxSupply`.
+
+Example `token-nft.json`:
+
+```json
+{
+  "name": "nft-keys-example",
+  "symbol": "NKE",
+  "supplyType": "infinite",
+  "treasuryKey": "alice-account",
+  "adminKey": "alice-account",
+  "supplyKey": "alice-account",
+  "memo": "Example NFT collection from file"
+}
+```
+
+Create the collection on the selected network:
+
+```sh
+hcli token create-nft-from-file --file ./token-nft.json
+```
+
+Optional fields include the same families of keys and thresholds as in code (`wipeKey`, `freezeKey`, `pauseKey`, `feeScheduleKey`, `associations`, and their threshold fields). For exact validation rules, rely on the CLI error output or the schema in the Hiero CLI repository (`NonFungibleTokenFileSchema`).

--- a/hedera/open-source-solutions/hiero-cli/plugins/topic-plugin.mdx
+++ b/hedera/open-source-solutions/hiero-cli/plugins/topic-plugin.mdx
@@ -36,7 +36,7 @@ hcli topic find-message \
 <Accordion title="Topic Create">
     Create a new Hedera Consensus Service topic with optional memo and keys.
 
-    <ResponseField name="-n, --name" type="string" required>
+    <ResponseField name="-n, --name" type="string">
         Define the name for this topic.
     </ResponseField>
 
@@ -44,13 +44,20 @@ hcli topic find-message \
         The memo for a topic.
     </ResponseField>
 
-    <ResponseField name="-a, --admin-key" type="string">
-        Pass an admin key as name or private key for the topic. Private key can be optionally prefixed with key type<br/>
-        (e.g., "ed25519:..." or "ecdsa:..."). Defaults to ecdsa if no prefix.
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        Admin key(s) of the topic. Pass multiple times for multiple keys. Format: `{accountId}:{privateKey}`, private key in `{ed25519|ecdsa}:private:{key}` format, key reference, or account alias.
     </ResponseField>
 
-    <ResponseField name="-s, --submit-key" type="string">
-        Submit key as account name or `{accountId}:{private_key}` format.
+    <ResponseField name="-s, --submit-key" type="string (repeatable)">
+        Submit key(s) of the topic. Pass multiple times for multiple keys. Format: `{accountId}:{privateKey}`, public/private key in `{ed25519|ecdsa}:public|private:{key}` format, key reference, or account alias.
+    </ResponseField>
+
+    <ResponseField name="-A, --admin-key-threshold" type="int">
+        Number of admin keys required to sign (M-of-N). Default: all keys must sign. Only applies when multiple `--admin-key` values are provided.
+    </ResponseField>
+
+    <ResponseField name="-S, --submit-key-threshold" type="int">
+        Number of submit keys required to sign (M-of-N). Default: all keys must sign. Only applies when multiple `--submit-key` values are provided.
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
@@ -58,12 +65,20 @@ hcli topic find-message \
     </ResponseField>
 </Accordion>
 
+<Accordion title="Topic Import">
+    Import an existing topic into state. Provide the topic ID (for example `0.0.123456`).
+
+    <ResponseField name="-t, --topic" type="string" required>
+        Topic ID to import (e.g., 0.0.123456)
+    </ResponseField>
+
+    <ResponseField name="-n, --name" type="string">
+        Name or alias for the topic
+    </ResponseField>
+</Accordion>
+
 <Accordion title="Topic List">
     List all topics stored in the state.
-
-    <ResponseField name="-n, --network" type="string">
-        Filter topics by network.
-    </ResponseField>
 </Accordion>
 
 <Accordion title="Topic Submit-Message">
@@ -77,13 +92,76 @@ hcli topic find-message \
         Submit a message to the topic.
     </ResponseField>
 
-    <ResponseField name="-s, --signer" type="string">
-        Account to use for signing the message. Can be an alias or `{accountId}:{private_key}`.<br/>
-        Required for public topics (without submit keys). For topics with submit keys, must be one of the authorized signers.
+    <ResponseField name="-s, --signer" type="string (repeatable)">
+        Key(s) to sign the message with. Pass multiple times for threshold topics. Can be `{accountId}:{privateKey}` pair, account private key in `{ed25519|ecdsa}:private:{private-key}` format, key reference, or account alias.
     </ResponseField>
 
     <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
         Key manager to use: local or local_encrypted (defaults to config setting)
+    </ResponseField>
+</Accordion>
+
+<Accordion title="Topic Update">
+    Update a Hedera Consensus Service topic. Requires admin key for most updates. Pass `null` to clear memo, submit key, or auto-renew account.
+
+    <ResponseField name="-t, --topic" type="string" required>
+        Topic ID or alias to update
+    </ResponseField>
+
+    <ResponseField name="-m, --memo" type="string">
+        New memo for the topic. Pass `null` to clear.
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        New admin key(s). Pass multiple times for multiple keys. Cannot be cleared, only replaced.
+    </ResponseField>
+
+    <ResponseField name="-s, --submit-key" type="string (repeatable)">
+        New submit key(s). Pass `null` to clear (makes the topic public).
+    </ResponseField>
+
+    <ResponseField name="-A, --admin-key-threshold" type="int">
+        Number of admin keys required to sign (M-of-N). Only applies when multiple `--admin-key` values are provided.
+    </ResponseField>
+
+    <ResponseField name="-S, --submit-key-threshold" type="int">
+        Number of submit keys required to sign (M-of-N). Only applies when multiple `--submit-key` values are provided.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager to use: local or local_encrypted (defaults to config setting)
+    </ResponseField>
+
+    <ResponseField name="-r, --auto-renew-account" type="string">
+        Auto-renew account ID or alias. Pass `null` to clear.
+    </ResponseField>
+
+    <ResponseField name="-p, --auto-renew-period" type="number">
+        Auto-renew period in seconds (min 2592000 / 30 days, max 8000000 / ~92 days)
+    </ResponseField>
+
+    <ResponseField name="-e, --expiration-time" type="string">
+        Expiration time as ISO datetime string
+    </ResponseField>
+</Accordion>
+
+<Accordion title="Topic Delete">
+    Delete a Hedera topic on the network and remove it from local state, or remove from local state only with `--state-only`.
+
+    <ResponseField name="-t, --topic" type="string" required>
+        Topic name or topic ID
+    </ResponseField>
+
+    <ResponseField name="-s, --state-only">
+        Remove only from local CLI state (no TopicDeleteTransaction on Hedera)
+    </ResponseField>
+
+    <ResponseField name="-a, --admin-key" type="string (repeatable)">
+        Admin credential(s) for signing TopicDeleteTransaction on Hedera. Required for network delete unless `--state-only` is used.
+    </ResponseField>
+
+    <ResponseField name="-k, --key-manager" type="string(local|local_encrypted)">
+        Key manager when resolving `--admin-key` (defaults to config)
     </ResponseField>
 </Accordion>
 

--- a/hedera/open-source-solutions/hiero-cli/scripting/quickstart.mdx
+++ b/hedera/open-source-solutions/hiero-cli/scripting/quickstart.mdx
@@ -6,20 +6,20 @@ title: "Quickstart"
 
 Hiero CLI scripts let you run repeatable, end-to-end workflows for Hedera: creating accounts, transferring HBAR, creating tokens, submitting topic messages, and more. These scripts are designed to be non-interactive (safe for CI).
 
-Example scripts live in:
-- [examples/scripts/*.sh](https://github.com/hiero-ledger/hiero-cli/tree/main/examples/scripts)
-- shared helpers: [examples/scripts/common/*](https://github.com/hiero-ledger/hiero-cli/tree/main/examples/scripts/common)
+Example scripts live in the [Hiero CLI repository](https://github.com/hiero-ledger/hiero-cli/tree/main/examples/scripts):
+
+- [`create-account-demo.sh`](https://github.com/hiero-ledger/hiero-cli/blob/main/examples/scripts/create-account-demo.sh) — operator setup, create account, view account
+- [`transfer-hbar-demo.sh`](https://github.com/hiero-ledger/hiero-cli/blob/main/examples/scripts/transfer-hbar-demo.sh) — two accounts and an HBAR transfer
+- [`token-topic-operations-demo.sh`](https://github.com/hiero-ledger/hiero-cli/blob/main/examples/scripts/token-topic-operations-demo.sh) — token and topic operations
+
+Shared helpers: [`examples/scripts/common/`](https://github.com/hiero-ledger/hiero-cli/tree/main/examples/scripts/common) (`helpers.sh`, `setup.sh`). See the folder’s [README](https://github.com/hiero-ledger/hiero-cli/blob/main/examples/scripts/README.md) for how to run the demos.
 
 ## Prerequisites
 
-- Node.js 18+
-- Build the CLI or have a globally installed version of the CLI 
-- Provide your Hedera operator credentials. Export these environment variables:
-
-```sh
-export HEDERA_OPERATOR_ACCOUNT_ID=0.0.xxxxxx
-export HEDERA_OPERATOR_KEY=302e020100300506032b657004220420...
-```
+- Node.js installation: 18.0.0 or higher
+- Local mode (default): clone [hiero-cli](https://github.com/hiero-ledger/hiero-cli), then in the project root run `npm install` and `npm run build` so `dist/hiero-cli.js` exists
+- Global mode (optional): install the CLI with `npm install -g @hiero-ledger/hiero-cli` and set `HIERO_SCRIPT_CLI_MODE=global` when running a script (see below)
+- Operator credentials: `HEDERA_OPERATOR_ACCOUNT_ID` and `HEDERA_OPERATOR_KEY`. Copy [`examples/scripts/.env.sample`](https://github.com/hiero-ledger/hiero-cli/blob/main/examples/scripts/.env.sample) to `examples/scripts/.env` and fill in your values, or export both variables in your shell
 
 <Tip>
   These are required for scripts that submit transactions to Hedera (e.g., create account, transfer, token operations).
@@ -40,85 +40,94 @@ set -euo pipefail
 - `-u` error on undefined variables
 - `-o` pipefail fail if any command in a pipe fails
 
-### Step 2: Load helpers & Setup
+### Step 2: Paths, helpers, and setup
 
-Scripts load shared utilities from examples/scripts/common/.
+Resolve the script directory and repository root, then source `common/helpers.sh` and `common/setup.sh`:
 
-Typical helpers include:
-- **structured log output** (print_step, print_info, print_error)
-- **random alias generator** (pick_random_name)
-- **sleep utilities** (sleep_loop) to wait for mirror-node consistency
+- **`helpers.sh`** — defines `run_hcli` (local vs global CLI), `print_step`, `print_info`, `print_warn`, `sleep_loop`, and `pick_random_name`
+- **`setup.sh`** — loads optional `examples/scripts/.env`, runs dependency/build checks in local mode, and validates required operator env vars
 
-### Step 3: `hcli()` wrapper (where automation begins)
+### Step 3: `run_hcli` (where automation begins)
 
-From this point, scripts start executing real CLI commands.
+From `helpers.sh`, commands go through `run_hcli` instead of calling `hcli` or `node dist/hiero-cli.js` directly:
 
 ```sh
-hcli() {
-  cd "${PROJECT_DIR}" && node dist/hiero-cli.js --format json "$@"
+export HIERO_SCRIPT_CLI_MODE="${HIERO_SCRIPT_CLI_MODE:-local}"
+
+run_hcli() {
+  if [[ "${HIERO_SCRIPT_CLI_MODE}" == "global" ]]; then
+    hcli --format json "$@"
+  else
+    (cd "${PROJECT_DIR}" && node dist/hiero-cli.js --format json "$@")
+  fi
 }
 ```
 
-Why this wrapper matters:
-- ensures commands run from the project root
-- uses the built CLI entrypoint
-- forces `--format json` so scripts don’t depend on human formatting
-- prevents interactive prompts (better for CI / automation)
+Why this matters:
 
-## Quickstart script: create an account and view it
+- Ensures every invocation uses `--format json` so scripts parse output reliably
+- Local: runs the built CLI from `PROJECT_DIR`
+- Global: runs the `hcli` on your `PATH` (after `npm install -g @hiero-ledger/hiero-cli`)
 
-This is the smallest “real” end-to-end example:
-- configure network + operator
-- create one account with 1 HBAR
-- view account details
+Set `HIERO_SCRIPT_CLI_MODE=global` when invoking a script if you do not want to build from source. The default is `local`.
 
-First, create a file called `create-account-quickstart.sh` with the below script contents:
+## Quickstart: create an account and view it
+
+The canonical example is `create-account-demo.sh`. From the `hiero-cli` repository root (with `HEDERA_OPERATOR_*` set or `.env` configured):
+
+```sh
+./examples/scripts/create-account-demo.sh
+```
+
+With a globally installed CLI:
+
+```sh
+HIERO_SCRIPT_CLI_MODE=global ./examples/scripts/create-account-demo.sh
+```
+
+The script configures testnet, sets the operator, creates one account with `1.0` HBAR, waits briefly for mirror indexing, then runs `account view`.
+
+<Note>
+#### `network use` in the example scripts
+
+When `HIERO_SCRIPT_CLI_MODE=global`, the demos call `network use --network testnet`. When using the default local build, they call `network use --global testnet`. Keep the same branch as the script you are running. If a command fails or the help text differs, use `hcli network use --help` for the CLI you actually execute.
+</Note>
+
+Below is the same sequence as in `create-account-demo.sh` (paths, `run_hcli`, operator setup, create + view). For a maintained, executable copy, use that file in the repo; this block is for reading the pattern:
 
 ```sh
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-# --- Helpers ---
-HELPERS="$SCRIPT_DIR/common/helpers.sh"
-SETUP="$SCRIPT_DIR/common/setup.sh"
-
-source "$HELPERS"
-source "$SETUP"
-
-# --- hcli wrapper (JSON output for scripting) ---
-hcli() {
-  cd "${PROJECT_DIR}" && node dist/hiero-cli.js --format json "$@"
-}
+source "$SCRIPT_DIR/common/helpers.sh"
+source "$SCRIPT_DIR/common/setup.sh"
 
 print_step "Selecting Hedera testnet as the active network"
-hcli network use --global testnet
+if [[ "${HIERO_SCRIPT_CLI_MODE}" == "global" ]]; then
+  run_hcli network use --network testnet
+else
+  run_hcli network use --global testnet
+fi
 
 print_step "Configuring CLI operator for testnet"
-hcli network set-operator \
+run_hcli network set-operator \
   --operator "${HEDERA_OPERATOR_ACCOUNT_ID}:${HEDERA_OPERATOR_KEY}" \
   --network testnet
 
 ACCOUNT_NAME="$(pick_random_name)"
 print_step "Creating demo account: ${ACCOUNT_NAME} (1 HBAR)"
-hcli account create --name "${ACCOUNT_NAME}" --balance 1.0
+run_hcli account create --name "${ACCOUNT_NAME}" --balance 1.0
 
-print_info "Waiting briefly for mirror node indexing..."
+print_info "Waiting for mirror node (sleep_loop 5)..."
 sleep_loop 5
 
 print_step "Viewing account ${ACCOUNT_NAME}"
-hcli account view --account "${ACCOUNT_NAME}"
+run_hcli account view --account "${ACCOUNT_NAME}"
 
 print_step "Done."
 ```
 
-Next, run it from the project root:
-
-```sh
-./examples/scripts/create-account-quickstart.sh
-```
-
-Start building your own scripts or explore other examples in the [Hiero CLI repository](https://github.com/hiero-ledger/hiero-cli/tree/main/examples/scripts).
+Explore the other demos and `examples/scripts/README.md` in the [Hiero CLI repository](https://github.com/hiero-ledger/hiero-cli/tree/main/examples/scripts).


### PR DESCRIPTION
## Summary

Updates the **Hiero CLI** documentation to better match current `@hiero-ledger/hiero-cli` behavior and the official plugin model: refreshed hub content, aligned existing plugin pages with manifests/help output, added missing plugin guides, adjusted navigation, and tightened the scripting quickstart.

## What changed

- **Overview** (`hiero-cli/overview.mdx`): Reworked intro, cards, and flows
- **Plugins**: Brought **network, hbar, account, token, topic, config, plugin-management** pages in line with the CLI; added full pages for **batch** (incl. [HIP-551](https://hips.hedera.com/hip/hip-551) context where relevant), **schedule**, **contract**, **contract ERC-20**, and **contract ERC-721**.
- **Navigation** (`docs.json`): Registered new routes and **reordered** the Plugins group to match the overview card order.
- **Scripting** (`hiero-cli/scripting/quickstart.mdx`): Aligned with official demo scripts and environment setup.
- **Cross-links / UX**: e.g. batch ↔ schedule where helpful; related links between contract token pages.
- **Open source solutions** (`open-source-solutions.mdx`): Adjusted Hiero CLI section presentation alongside the above.

## Important note

The documentation changes in this pull request are based on a local build that is significantly more up to date than the latest release currently published on npm.