### PR TITLE
docs: update egress port requirement

### DIFF
--- a/hedera/networks/mainnet/mainnet-nodes/node-requirements.mdx
+++ b/hedera/networks/mainnet/mainnet-nodes/node-requirements.mdx
@@ -331,8 +331,8 @@ The following ports must be configured for **public internet access** unless oth
 | Port    | Protocol | Direction      | Description                           |
 | ------- | -------- | -------------- | ------------------------------------- |
 | `50111` | TCP      | Ingress/Egress | Gossip protocol                       |
-| `50211` | TCP      | Ingress        | gRPC (public) API access (HAPI)       |
-| `50212` | TCP      | Ingress        | TLS-encrypted gRPC                    |
+| `50211` | TCP      | Ingress/Egress | gRPC (public) API access (HAPI)       |
+| `50212` | TCP      | Ingress/Egress | TLS-encrypted gRPC                    |
 | `80`    | TCP      | Egress only    | OS package repository connectivity    |
 | `443`   | TCP      | Egress only    | Secure package & system update access |
 | `123`   | UDP      | Ingress/Egress | Time sync via NTP pool                |


### PR DESCRIPTION
**Description**:
Update node requirements doc to list port 50211 / 50212 as requiring both ingress and egress

**Related issue(s)**:
Fixes #514
