### PR TITLE
docs: Fix Developer Examples links in quickstart.mdx

### DIFF
--- a/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hedera-agent-kit-js/quickstart.mdx
+++ b/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hedera-agent-kit-js/quickstart.mdx
@@ -246,24 +246,24 @@ This tool has two execution modes with AI agents:
 
 - **GitHub**: https://github.com/hashgraph/hedera-agent-kit-js
 - **Issues**: https://github.com/hashgraph/hedera-agent-kit-js/issues
-- **Developer Examples**: [DEVEXAMPLES.md](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md)
+- **Developer Examples**: [DEVEXAMPLES.md](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md)
 
 ## Examples
 
-Clone the repository and try out different example agents. See the full [Developer Examples](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md) documentation for detailed setup instructions.
+Clone the repository and try out different example agents. See the full [Developer Examples](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md) documentation for detailed setup instructions.
 
 **Available Examples:**
 
-- **Option A** - [Example Tool Calling Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-a-run-the-example-tool-calling-agent)
-- **Option B** - [Example Structured Chat Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-b-run-the-structured-chat-agent-langchain-v03-only)
-- **Option C** - [Example Return Bytes Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-c-try-the-human-in-the-loop-chat-agent)
-- **Option D** - [Example MCP Server](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-d-try-out-the-mcp-server)
-- **Option E** - [Example External MCP Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-e-try-out-the-external-mcp-agent)
-- **Option F** - [Example ElizaOS Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-f-try-out-the-hedera-agent-kit-with-elizaos)
-- **Option G** - [Example Preconfigured MCP Client Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-g-try-out-the-preconfigured-mcp-client-agent)
-- **Option H** - [Example Policy Enforcement Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-h-run-the-policy-enforcement-agent)
-- **Option I** - [Example Audit Trail Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-i-run-the-audit-trail-agent)
-- **Option J** - [Example Google ADK Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/feat/release/16.04/docs/DEVEXAMPLES.md#option-j-try-out-the-google-adk-agent)
+- **Option A** - [Example Tool Calling Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-a-run-the-example-tool-calling-agent)
+- **Option B** - [Example Structured Chat Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-b-run-the-structured-chat-agent-langchain-v03-only)
+- **Option C** - [Example Return Bytes Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-c-try-the-human-in-the-loop-chat-agent)
+- **Option D** - [Example MCP Server](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-d-try-out-the-mcp-server)
+- **Option E** - [Example External MCP Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-e-try-out-the-external-mcp-agent)
+- **Option F** - [Example ElizaOS Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-f-try-out-the-hedera-agent-kit-with-elizaos)
+- **Option G** - [Example Preconfigured MCP Client Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-g-try-out-the-preconfigured-mcp-client-agent)
+- **Option H** - [Example Policy Enforcement Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-h-run-the-policy-enforcement-agent)
+- **Option I** - [Example Audit Trail Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-i-run-the-audit-trail-agent)
+- **Option J** - [Example Google ADK Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-j-try-out-the-google-adk-agent)
 
 
 **NPM packages:**


### PR DESCRIPTION
Updated links to Developer Examples documentation to point to the main branch instead of a specific feature release.