### PR TITLE
docs: Improve formatting of migration guides for JavaScript and Python

### DIFF
--- a/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hooks-and-polices.mdx
+++ b/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hooks-and-polices.mdx
@@ -19,9 +19,11 @@ These can be used to enforce security, compliance, and other business rules.
   
   Only tools extending `BaseTool` (JavaScript) or `ToolV2` (Python) support hooks and policies. All core tools provided with the kit support these features by default. While classic tool interfaces continue to be supported for backward compatibility, they do not gain hook or policy support until migrated to the new base classes.
   
-  <Accordion title="Migration Guides">
-    - **JavaScript**: [Migrating Custom Tools to BaseTool](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/MIGRATION-v4.md#migrating-custom-tools-to-basetool-recommended-non-breaking)
-    - **Python**: [Python ToolV2 Migration Guide](https://github.com/hashgraph/hedera-agent-kit-py/blob/main/docs/MIGRATION_TO_BASETOOLV2.md)
+  <Accordion title="Migration Guides">  
+
+   **JavaScript**: [Migrating Custom Tools to BaseTool](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/MIGRATION-v4.md#migrating-custom-tools-to-basetool-recommended-non-breaking)  
+
+  **Python**: [Python ToolV2 Migration Guide](https://github.com/hashgraph/hedera-agent-kit-py/blob/main/docs/MIGRATION_TO_BASETOOLV2.md)
   </Accordion>
 
 </Note>


### PR DESCRIPTION
Updated the formatting of migration guides for JavaScript and Python in the hooks and policies documentation.