### PR TITLE
fix: broken Solo docs link

### DIFF
--- a/snippets/local-node-deprecation.mdx
+++ b/snippets/local-node-deprecation.mdx
@@ -1,4 +1,4 @@
 <Warning>
 **Hiero Local Node Deprecation (September 2026)**
-Hiero Local Node is entering a 6-month deprecation period. Support ends September 2026. Migrate local testing and CI workflows to [Solo](https://solo.hiero.org/v0.60.0/docs) before then. [Learn more](https://hedera.com/blog/hiero-local-node-deprecation-6-month-transition-to-solo/).
+Hiero Local Node is entering a 6-month deprecation period. Support ends September 2026. Migrate local testing and CI workflows to [Solo](https://solo.hiero.org/docs/) before then. [Learn more](https://hedera.com/blog/hiero-local-node-deprecation-6-month-transition-to-solo/).
 </Warning>


### PR DESCRIPTION
Fixes the Solo docs URL referenced from the local node deprecation warning.

- Old: https://solo.hiero.org/v0.60.0/docs (404)
- New: https://solo.hiero.org/docs/ (200)

Fixes #560.