### PR TITLE
fix: redirect legacy /hedera/readme to /learn

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2075,6 +2075,10 @@
     {
       "source": "/hedera/tutorials/token/hybrid-hts-+-evm-tokenization",
       "destination": "/evm/tutorials/hedera/hybrid-hts-evm"
+    },
+    {
+      "source": "/hedera/readme",
+      "destination": "/learn"
     }
   ],
   "navigation": {


### PR DESCRIPTION
## Summary

Adds a single redirect: `/hedera/readme` → `/learn`.

`/hedera/readme` (the old home page URL) was the one legacy `/hedera/` URL with no redirect — it had been served directly by `hedera/readme.mdx`. When the `hedera/` tree was removed in #623, that file went away and the URL started returning **404**. This adds the missing redirect to the new Learn landing.

## Verification
- Live-swept all 549 legacy `/hedera/` URLs after #623 deployed: 548 resolve, this was the only genuine 404.
- Target `/learn` is live (200) and backed by `learn/index.mdx`.
- docs.json valid; diff is the single redirect entry.