### PR TITLE
chore: add mirror node release notes automation

### DIFF
--- a/.github/scripts/mirror-node-release-entry.js
+++ b/.github/scripts/mirror-node-release-entry.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+// Generates and prepends a mirror node release notes MDX entry.
+// Usage:
+// node mirror-node-release-entry.js --version X.Y.Z --release-json release.json --target path/to/mirror-node.mdx
+
+'use strict';
+
+const fs = require('fs');
+
+const REPO_URL = 'https://github.com/hiero-ledger/hiero-mirror-node';
+
+// The only categories rendered as accordions on this page, in this order.
+// The release body also emits "Breaking Changes" (rewritten as editorial prose
+// by a human), "Deployments", and "Contributors" — all intentionally dropped.
+const RENDER_CATEGORIES = ['Enhancements', 'Bug Fixes', 'Dependency Upgrades'];
+
+const ANCHOR_REGEX = /^##\s+Latest Releases\s*\r?\n/m;
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+
+    if (!key || !key.startsWith('--')) {
+      throw new Error(`Invalid argument "${key || ''}". Expected --key value.`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for argument "${key}".`);
+    }
+
+    parsed[key.slice(2)] = value;
+  }
+
+  return parsed;
+}
+
+function normalizeVersion(input) {
+  const raw = String(input || '').trim();
+  const version = raw.replace(/^v/i, '');
+
+  if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid version "${raw}". Expected X.Y.Z or vX.Y.Z.`);
+  }
+
+  return version;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeMdxAttribute(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function readFile(path) {
+  try {
+    return fs.readFileSync(path, 'utf8');
+  } catch (error) {
+    throw new Error(`Could not read "${path}": ${error.message}`);
+  }
+}
+
+function writeFile(path, content) {
+  try {
+    fs.writeFileSync(path, content, 'utf8');
+  } catch (error) {
+    throw new Error(`Could not write "${path}": ${error.message}`);
+  }
+}
+
+// The release body opens with a prose summary before the first `## Category`
+// header. Copy it verbatim (minus a leading `# ...` title) as the entry's
+// summary paragraph — markdown-escaped punctuation is unescaped to match the page.
+function extractSummary(body) {
+  const summaryLines = [];
+
+  for (const line of body.split(/\r?\n/)) {
+    if (/^##\s/.test(line)) break; // stop at the first category header
+    if (/^#\s/.test(line)) continue; // skip a leading H1 title (e.g. "# Release Notes")
+    summaryLines.push(line);
+  }
+
+  return summaryLines
+    .join('\n')
+    .replace(/\\([^A-Za-z0-9])/g, '$1')
+    .trim();
+}
+
+function parseReleaseBody(body) {
+  const blocks = new Map();
+  let currentCategory = null;
+
+  for (const line of body.split(/\r?\n/)) {
+    const headerMatch = line.match(/^##\s+(.+?)\s*$/);
+
+    if (headerMatch) {
+      currentCategory = headerMatch[1].trim();
+
+      if (!blocks.has(currentCategory)) {
+        blocks.set(currentCategory, []);
+      }
+
+      continue;
+    }
+
+    if (currentCategory && /^[-*]\s+/.test(line)) {
+      // Normalize a release-body bullet to this page's style:
+      //  - strip the leading marker
+      //  - reduce PR links `[#NNN](url)` to the plain `#NNN` ref the page uses
+      //  - unescape markdown-escaped punctuation (e.g. `\_` -> `_`)
+      const bullet = line
+        .replace(/^[-*]\s+/, '')
+        .replace(/\[#(\d+)\]\([^)]*\)/g, '#$1')
+        .replace(/\\([^A-Za-z0-9])/g, '$1')
+        .trimEnd();
+
+      if (bullet.trim()) {
+        blocks.get(currentCategory).push(`  * ${bullet}`);
+      }
+    }
+  }
+
+  return blocks;
+}
+
+function buildCategoryOrder(blocks) {
+  // Only the canonical accordion categories, in canonical order, that have
+  // content. Everything else in the body (Breaking Changes, Deployments,
+  // Contributors, anything new) is intentionally not rendered as an accordion.
+  const orderedCategories = RENDER_CATEGORIES.filter(
+    category => blocks.has(category) && blocks.get(category).length > 0
+  );
+
+  return { orderedCategories };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  const version = normalizeVersion(args.version);
+  const releaseJsonPath = args['release-json'];
+  const target = args.target;
+
+  if (!releaseJsonPath || !target) {
+    throw new Error(
+      'Usage: node mirror-node-release-entry.js --version X.Y.Z --release-json release.json --target path/to/mirror-node.mdx'
+    );
+  }
+
+  const releaseJson = readFile(releaseJsonPath);
+  const existingContent = readFile(target);
+
+  let release;
+
+  try {
+    release = JSON.parse(releaseJson);
+  } catch (error) {
+    throw new Error(`Could not parse release JSON from "${releaseJsonPath}": ${error.message}`);
+  }
+
+  const expectedTag = `v${version}`;
+  const tagName = typeof release.tagName === 'string' ? release.tagName : expectedTag;
+
+  if (tagName !== expectedTag) {
+    throw new Error(`Release tag mismatch. Expected "${expectedTag}", got "${tagName}".`);
+  }
+
+  const body = typeof release.body === 'string' ? release.body : '';
+  const tagUrl =
+    typeof release.url === 'string' && release.url.length > 0
+      ? release.url
+      : `${REPO_URL}/releases/tag/${expectedTag}`;
+
+  const duplicateHeadingRegex = new RegExp(`^## \\[v${escapeRegExp(version)}\\]`, 'm');
+
+  if (duplicateHeadingRegex.test(existingContent)) {
+    console.log(`v${version} entry already exists in ${target}. Skipping.`);
+    return;
+  }
+
+  const blocks = parseReleaseBody(body);
+  const { orderedCategories } = buildCategoryOrder(blocks);
+
+  const totalBullets = orderedCategories.reduce(
+    (sum, category) => sum + blocks.get(category).length,
+    0
+  );
+
+  if (totalBullets === 0) {
+    throw new Error(
+      `No bullets parsed from release body for v${version}.\n` +
+        `The upstream release body format may have changed. Review manually:\n${body.slice(0, 500)}`
+    );
+  }
+
+  const accordions = orderedCategories
+    .map(category => {
+      const title = escapeMdxAttribute(category);
+      return `<Accordion title="${title}">\n${blocks.get(category).join('\n')}\n</Accordion>`;
+    })
+    .join('\n\n');
+
+  const warnings = [];
+
+  // Breaking Changes are rewritten as editorial prose by a human, not rendered
+  // as an accordion. If the body has a Breaking Changes section, flag it.
+  if (blocks.has('Breaking Changes')) {
+    warnings.push(
+      '<!-- TODO: this release has Breaking Changes in the upstream notes — add a "### Breaking Changes" prose section above the accordions. -->'
+    );
+  }
+
+  // The entry opens with the release's own summary prose, copied verbatim from
+  // the body. If the body has no preamble (e.g. a small patch release), omit it
+  // entirely — no placeholder.
+  const summary = extractSummary(body);
+
+  const parts = [`## [v${version}](${tagUrl})`, ''];
+  if (summary) parts.push(summary, '');
+  if (warnings.length > 0) parts.push(...warnings, '');
+  parts.push(accordions, '', '');
+
+  const entry = parts.join('\n');
+
+  const anchorMatch = existingContent.match(ANCHOR_REGEX);
+
+  if (!anchorMatch || anchorMatch.index === undefined) {
+    throw new Error(`Could not find "## Latest Releases" anchor in ${target}.`);
+  }
+
+  const insertPosition = anchorMatch.index + anchorMatch[0].length;
+  const updated =
+    existingContent.slice(0, insertPosition) +
+    '\n' +
+    entry +
+    existingContent.slice(insertPosition);
+
+  writeFile(target, updated);
+
+  console.log(
+    `Prepended v${version} entry to ${target} (${totalBullets} bullets across ${orderedCategories.length} categories).`
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/.github/scripts/select-backfill-versions.js
+++ b/.github/scripts/select-backfill-versions.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Determines which upstream releases are missing from the release-notes page.
+// Prints the missing stable versions newer than the latest documented one,
+// oldest-first, one per line. The caller adds them in that order so the newest
+// ends up at the top of the page.
+//
+// Usage:
+// node select-backfill-versions.js --target path/to/notes.mdx --releases releases.json
+//
+// releases.json is the output of:
+//   gh release list --repo <repo> --exclude-pre-releases --exclude-drafts --json tagName
+
+'use strict';
+
+const fs = require('fs');
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+
+    if (!key || !key.startsWith('--')) {
+      throw new Error(`Invalid argument "${key || ''}". Expected --key value.`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for argument "${key}".`);
+    }
+
+    parsed[key.slice(2)] = value;
+  }
+
+  return parsed;
+}
+
+function normalizeVersion(tag) {
+  return String(tag || '').trim().replace(/^v/i, '');
+}
+
+// Only stable X.Y.Z releases — drop anything with a prerelease suffix.
+function isStable(version) {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+
+  return 0;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const target = args.target;
+  const releasesPath = args.releases;
+
+  if (!target || !releasesPath) {
+    throw new Error(
+      'Usage: node select-backfill-versions.js --target path/to/notes.mdx --releases releases.json'
+    );
+  }
+
+  const content = fs.readFileSync(target, 'utf8');
+
+  // The latest documented version is the first stable X.Y.Z heading on the page.
+  const headingMatch = content.match(/^## \[v(\d+\.\d+\.\d+)\]/m);
+  if (!headingMatch) {
+    throw new Error(`Could not find a documented "## [vX.Y.Z]" heading in ${target}.`);
+  }
+  const documentedLatest = headingMatch[1];
+
+  let releases;
+  try {
+    releases = JSON.parse(fs.readFileSync(releasesPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not parse releases JSON from "${releasesPath}": ${error.message}`);
+  }
+
+  if (!Array.isArray(releases)) {
+    throw new Error(`Expected releases JSON to be an array, got ${typeof releases}.`);
+  }
+
+  const missing = releases
+    .map(release => normalizeVersion(release.tagName))
+    .filter(isStable)
+    .filter(version => compareVersions(version, documentedLatest) > 0)
+    .sort(compareVersions); // oldest first
+
+  for (const version of missing) {
+    console.log(version);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/.github/workflows/mirror-node-release-notes.yml
+++ b/.github/workflows/mirror-node-release-notes.yml
@@ -56,39 +56,39 @@ jobs:
           if [[ -n "${VERSION_INPUT}" ]]; then
             # Single-version mode: validate and use exactly the requested version.
             VERSION="${VERSION_INPUT#v}"
-            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
               echo "Invalid version: ${VERSION_INPUT}" >&2
               echo "Expected X.Y.Z or vX.Y.Z, for example 0.155.1 or v0.155.1." >&2
               exit 1
             fi
-            echo "$VERSION" > "$RUNNER_TEMP/versions.txt"
+            echo "${VERSION}" > "${RUNNER_TEMP}/versions.txt"
           else
             # Backfill mode: every stable release newer than the latest on the page.
             gh release list \
-              --repo "$REPO" \
+              --repo "${REPO}" \
               --exclude-pre-releases \
               --exclude-drafts \
               --limit 100 \
               --json tagName \
-              > "$RUNNER_TEMP/releases.json"
+              > "${RUNNER_TEMP}/releases.json"
 
             node .github/scripts/select-backfill-versions.js \
-              --target "$TARGET" \
-              --releases "$RUNNER_TEMP/releases.json" \
-              > "$RUNNER_TEMP/versions.txt"
+              --target "${TARGET}" \
+              --releases "${RUNNER_TEMP}/releases.json" \
+              > "${RUNNER_TEMP}/versions.txt"
           fi
 
-          COUNT="$(grep -c . "$RUNNER_TEMP/versions.txt" || true)"
-          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          COUNT="$(grep -c . "${RUNNER_TEMP}/versions.txt" || true)"
+          echo "count=${COUNT}" >> "${GITHUB_OUTPUT}"
 
           if [[ "$COUNT" -eq 0 ]]; then
             echo "No missing releases — nothing to do."
           else
             echo "Will add $COUNT release(s):"
-            cat "$RUNNER_TEMP/versions.txt"
+            cat "${RUNNER_TEMP}/versions.txt"
             # Comma-separated v-prefixed list for the PR title/commit message.
-            CSV="$(sed 's/^/v/' "$RUNNER_TEMP/versions.txt" | paste -sd, -)"
-            echo "versions_csv=${CSV}" >> "$GITHUB_OUTPUT"
+            CSV="$(sed 's/^/v/' "${RUNNER_TEMP}/versions.txt" | paste -sd, -)"
+            echo "versions_csv=${CSV}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Generate MDX entries
@@ -101,19 +101,19 @@ jobs:
 
           # Oldest-first so the newest release ends up prepended last (on top).
           while IFS= read -r VERSION; do
-            [[ -z "$VERSION" ]] && continue
+            [[ -z "${VERSION}" ]] && continue
             echo "::group::v${VERSION}"
             gh release view "v${VERSION}" \
-              --repo "$REPO" \
+              --repo "${REPO}" \
               --json body,tagName,url \
-              > "$RUNNER_TEMP/release.json"
+              > "${RUNNER_TEMP}/release.json"
 
             node .github/scripts/mirror-node-release-entry.js \
-              --version "$VERSION" \
-              --release-json "$RUNNER_TEMP/release.json" \
-              --target "$TARGET"
+              --version "${VERSION}" \
+              --release-json "${RUNNER_TEMP}/release.json" \
+              --target "${TARGET}"
             echo "::endgroup::"
-          done < "$RUNNER_TEMP/versions.txt"
+          done < "${RUNNER_TEMP}/versions.txt"
 
       - name: Open pull request
         if: steps.plan.outputs.count != '0'

--- a/.github/workflows/mirror-node-release-notes.yml
+++ b/.github/workflows/mirror-node-release-notes.yml
@@ -37,10 +37,10 @@ jobs:
           egress-policy: audit
 
       - name: Checkout docs repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
 

--- a/.github/workflows/mirror-node-release-notes.yml
+++ b/.github/workflows/mirror-node-release-notes.yml
@@ -1,0 +1,147 @@
+name: Mirror Node Release Notes
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'A specific version to add (e.g. 0.155.1). Leave blank to backfill every missing release.'
+        required: false
+        type: string
+  schedule:
+    # Daily at 07:00 UTC. Safety net in case no push to main happened that day.
+    - cron: '0 7 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TARGET: learn/release-notes/mirror-node.mdx
+  REPO: hiero-ledger/hiero-mirror-node
+
+jobs:
+  add-release-notes:
+    runs-on: hashgraph-docs-linux-medium
+
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout docs repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        with:
+          node-version: '22'
+
+      - name: Plan versions to add
+        id: plan
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${VERSION_INPUT}" ]]; then
+            # Single-version mode: validate and use exactly the requested version.
+            VERSION="${VERSION_INPUT#v}"
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid version: ${VERSION_INPUT}" >&2
+              echo "Expected X.Y.Z or vX.Y.Z, for example 0.155.1 or v0.155.1." >&2
+              exit 1
+            fi
+            echo "$VERSION" > "$RUNNER_TEMP/versions.txt"
+          else
+            # Backfill mode: every stable release newer than the latest on the page.
+            gh release list \
+              --repo "$REPO" \
+              --exclude-pre-releases \
+              --exclude-drafts \
+              --limit 100 \
+              --json tagName \
+              > "$RUNNER_TEMP/releases.json"
+
+            node .github/scripts/select-backfill-versions.js \
+              --target "$TARGET" \
+              --releases "$RUNNER_TEMP/releases.json" \
+              > "$RUNNER_TEMP/versions.txt"
+          fi
+
+          COUNT="$(grep -c . "$RUNNER_TEMP/versions.txt" || true)"
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No missing releases — nothing to do."
+          else
+            echo "Will add $COUNT release(s):"
+            cat "$RUNNER_TEMP/versions.txt"
+            # Comma-separated v-prefixed list for the PR title/commit message.
+            CSV="$(sed 's/^/v/' "$RUNNER_TEMP/versions.txt" | paste -sd, -)"
+            echo "versions_csv=${CSV}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate MDX entries
+        if: steps.plan.outputs.count != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Oldest-first so the newest release ends up prepended last (on top).
+          while IFS= read -r VERSION; do
+            [[ -z "$VERSION" ]] && continue
+            echo "::group::v${VERSION}"
+            gh release view "v${VERSION}" \
+              --repo "$REPO" \
+              --json body,tagName,url \
+              > "$RUNNER_TEMP/release.json"
+
+            node .github/scripts/mirror-node-release-entry.js \
+              --version "$VERSION" \
+              --release-json "$RUNNER_TEMP/release.json" \
+              --target "$TARGET"
+            echo "::endgroup::"
+          done < "$RUNNER_TEMP/versions.txt"
+
+      - name: Open pull request
+        if: steps.plan.outputs.count != '0'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: learn/release-notes/mirror-node.mdx
+          commit-message: "docs: add mirror node release notes (${{ steps.plan.outputs.versions_csv }})"
+          signoff: true
+          sign-commits: true
+          branch: automation/mirror-node-release-notes
+          title: "docs: mirror node release notes (${{ steps.plan.outputs.versions_csv }})"
+          assignees: ${{ github.actor }}
+          labels: automated-pr
+          delete-branch: true
+          body: |
+            ## Mirror Node Release Notes
+
+            This PR adds the following mirror node release notes: **${{ steps.plan.outputs.versions_csv }}**
+
+            Source: https://github.com/hiero-ledger/hiero-mirror-node/releases
+
+            ### Review checklist
+
+            - [ ] Verify bullets are accurate and complete
+            - [ ] Confirm the summary prose copied from each release body reads well (edit if needed)
+            - [ ] If flagged, add a `### Breaking Changes` prose section above the accordions
+            - [ ] Check for HIP references that should link to hips.hedera.com
+
+            ---
+            This PR was generated by the mirror node release notes workflow.


### PR DESCRIPTION
## summary

adds automation that keeps the mirror node release notes (`learn/release-notes/mirror-node.mdx`) up to date from the upstream `hiero-ledger/hiero-mirror-node` releases. on a new release it generates the release entry, prepends it under `## latest releases`, and opens a PR for review.

fixes #71, fixes #73 
## what it does

- **triggers** - push to `main`, daily schedule (07:00 UTC safety net), and manual dispatch.
- **backfill (default)** - a blank/scheduled run finds every stable release newer than the latest on the page and adds them all in one PR, newest on top. pre-releases (`-rc`) and drafts are excluded.
- **single version** - dispatch with a version (e.g. `0.155.1`) to add just that one.
- **release entry** - copies the summary prose verbatim from the release body (omitted entirely when a patch release has none, so no TODO placeholder leaks through), then renders only the canonical `enhancements`, `bug fixes`, and `dependency upgrades` accordions. PR links are flattened to plain `#NNNN` and `\_` is unescaped to match the existing page format.
- **idempotent** - releases already on the page are skipped, so reruns and the daily schedule never duplicate.
- PRs are opened with DCO sign-off and assigned to the triggering actor.

## files

- `.github/workflows/mirror-node-release-notes.yml` - the workflow
- `.github/scripts/mirror-node-release-entry.js` - generates/prepends the release entry
- `.github/scripts/select-backfill-versions.js` - lists releases missing from the page

## notes

- the workflow only opens a PR; nothing is auto-merged. the PR body includes a review checklist (verify bullets, confirm the copied summary reads well, flag breaking changes, check HIP links).
- breaking changes are flagged with a TODO for a human to write the prose callout.
- actions pinned to checkout v5.0.1 / setup-node v5.0.0 (node24 runtime) ahead of github's 2026 node 24 migration; the rest of the repo is still on v4.

## follow-up

- the companion consensus-node automation is in #635.
