### PR TITLE
chore: add consensus node release notes automation

### DIFF
--- a/.github/scripts/consensus-node-release-entry.js
+++ b/.github/scripts/consensus-node-release-entry.js
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+// Generates and inserts a consensus node release notes build block.
+// Usage:
+// node consensus-node-release-entry.js --version X.Y.Z --release-json release.json --target path/to/services.mdx [--status-json status.json]
+//
+// Consensus node release notes nest per-build changelog blocks under a
+// human-curated "## Release vX.Y" minor section. This script owns the
+// mechanical build block. When the minor section does not yet exist (a new
+// minor release), it scaffolds a stub section with placeholder editorial
+// content for a human to fill in.
+
+'use strict';
+
+const fs = require('fs');
+
+const REPO_URL = 'https://github.com/hiero-ledger/hiero-consensus-node';
+const GITHUB_URL = 'https://github.com';
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+
+    if (!key || !key.startsWith('--')) {
+      throw new Error(`Invalid argument "${key || ''}". Expected --key value.`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for argument "${key}".`);
+    }
+
+    parsed[key.slice(2)] = value;
+  }
+
+  return parsed;
+}
+
+function normalizeVersion(input) {
+  const raw = String(input || '').trim();
+  const version = raw.replace(/^v/i, '');
+
+  if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid version "${raw}". Expected X.Y.Z or vX.Y.Z.`);
+  }
+
+  return version;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function readFile(path) {
+  try {
+    return fs.readFileSync(path, 'utf8');
+  } catch (error) {
+    throw new Error(`Could not read "${path}": ${error.message}`);
+  }
+}
+
+function writeFile(path, content) {
+  try {
+    fs.writeFileSync(path, content, 'utf8');
+  } catch (error) {
+    throw new Error(`Could not write "${path}": ${error.message}`);
+  }
+}
+
+// Link a trailing "by @user" handle to the contributor's GitHub profile.
+function linkAuthor(bullet) {
+  return bullet.replace(
+    /\bby @([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\s*$/,
+    (match, handle) => `by [@${handle}](${GITHUB_URL}/${handle})`
+  );
+}
+
+// Parse the release body into ordered [category, bullets[]] pairs, preserving
+// the order categories appear in the release body.
+function parseReleaseBody(body) {
+  const categories = [];
+  let current = null;
+
+  for (const line of body.split(/\r?\n/)) {
+    // Category headers are level-2 ("## Features"). Ignore the top-level
+    // "# Release Notes" title and anything deeper.
+    const headerMatch = line.match(/^##\s+(.+?)\s*$/);
+
+    if (headerMatch) {
+      current = { title: headerMatch[1].trim(), bullets: [] };
+      categories.push(current);
+      continue;
+    }
+
+    if (current && /^[-*]\s+/.test(line)) {
+      // Strip the bullet marker and collapse internal runs of whitespace
+      // (the release body sometimes has stray double spaces before PR links).
+      const bullet = line
+        .replace(/^[-*]\s+/, '')
+        .replace(/[ \t]{2,}/g, ' ')
+        .trimEnd();
+
+      if (bullet.trim()) {
+        current.bullets.push(`  * ${linkAuthor(bullet)}`);
+      }
+    }
+  }
+
+  return categories.filter(category => category.bullets.length > 0);
+}
+
+function buildChangelogBlock(version, tagUrl, categories) {
+  const categoryBlocks = categories
+    .map(category => `### **${category.title}**\n\n${category.bullets.join('\n')}`)
+    .join('\n\n');
+
+  return [
+    `### [**Build ${version}**](${tagUrl})`,
+    '',
+    `<Accordion title="What's Changed">`,
+    '',
+    categoryBlocks,
+    '',
+    `  **Full Release Notes**: [**v${version}**](${tagUrl})`,
+    '',
+    `</Accordion>`,
+    '',
+  ].join('\n');
+}
+
+const MONTHS = [
+  'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE',
+  'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER',
+];
+
+// Format an ISO timestamp as the page's date style, e.g. "JUNE 10, 2026".
+function formatStatusDate(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
+}
+
+// Read the Hedera status page's scheduled-maintenances payload, if provided.
+function readStatusMaintenances(path) {
+  if (!path) return null;
+  try {
+    const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+    return Array.isArray(data.scheduled_maintenances) ? data.scheduled_maintenances : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+// Find the upgrade-window date for a given network + version from the status
+// maintenances. Matches names like "Mainnet Upgrade to v0.74" (-> 0.74.0) or
+// "Testnet Upgrade to v0.74.0". Returns { date, completed } or null.
+function findUpgradeDate(maintenances, network, version) {
+  if (!maintenances) return null;
+
+  const matches = [];
+  for (const m of maintenances) {
+    const name = m.name || '';
+    if (!name.toLowerCase().includes(network.toLowerCase())) continue;
+    if (!/upgrade/i.test(name)) continue;
+
+    const versionMatch = name.match(/v?(\d+\.\d+(?:\.\d+)?)/);
+    if (!versionMatch) continue;
+
+    let found = versionMatch[1];
+    if (/^\d+\.\d+$/.test(found)) found += '.0'; // normalize minor-only to X.Y.0
+    if (found !== version) continue;
+
+    const iso = m.scheduled_for || m.created_at;
+    if (iso) matches.push({ iso, completed: m.status === 'completed' });
+  }
+
+  if (matches.length === 0) return null;
+
+  // Prefer the most recent matching window.
+  matches.sort((a, b) => new Date(b.iso) - new Date(a.iso));
+  const date = formatStatusDate(matches[0].iso);
+  return date ? { date, completed: matches[0].completed } : null;
+}
+
+// Render a network status line. Completed upgrades use <Check>/"UPDATED";
+// upcoming ones use <Info>/"UPDATE". Falls back to a TODO when the status page
+// has no date for this version yet.
+function networkBlock(label, info) {
+  if (!info) {
+    return [`<Info>`, `  **${label} UPDATE: TODO**`, `</Info>`];
+  }
+  if (info.completed) {
+    return [`<Check>`, `  **${label} UPDATED: ${info.date}**`, `</Check>`];
+  }
+  return [`<Info>`, `  **${label} UPDATE: ${info.date}**`, `</Info>`];
+}
+
+function buildStubMinorSection(minor, version, changelogBlock, maintenances) {
+  const mainnet = findUpgradeDate(maintenances, 'Mainnet', version);
+  const testnet = findUpgradeDate(maintenances, 'Testnet', version);
+
+  return [
+    `## Release v${minor}`,
+    ...networkBlock('MAINNET', mainnet),
+    ...networkBlock('TESTNET', testnet),
+    '',
+    `<!-- highlights: TODO - add a "### Release highlights" paragraph and a "What's new in Release v${minor}?" accordion above the build block -->`,
+    '',
+    changelogBlock,
+  ].join('\n');
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  const version = normalizeVersion(args.version);
+  const releaseJsonPath = args['release-json'];
+  const target = args.target;
+  // Optional: Hedera status page scheduled-maintenances JSON, used to fill in
+  // mainnet/testnet upgrade dates when scaffolding a new minor section.
+  const maintenances = readStatusMaintenances(args['status-json']);
+
+  if (!releaseJsonPath || !target) {
+    throw new Error(
+      'Usage: node consensus-node-release-entry.js --version X.Y.Z --release-json release.json --target path/to/services.mdx [--status-json status.json]'
+    );
+  }
+
+  const releaseJson = readFile(releaseJsonPath);
+  const existingContent = readFile(target);
+
+  let release;
+
+  try {
+    release = JSON.parse(releaseJson);
+  } catch (error) {
+    throw new Error(`Could not parse release JSON from "${releaseJsonPath}": ${error.message}`);
+  }
+
+  const expectedTag = `v${version}`;
+  const tagName = typeof release.tagName === 'string' ? release.tagName : expectedTag;
+
+  if (tagName !== expectedTag) {
+    throw new Error(`Release tag mismatch. Expected "${expectedTag}", got "${tagName}".`);
+  }
+
+  const body = typeof release.body === 'string' ? release.body : '';
+  const tagUrl =
+    typeof release.url === 'string' && release.url.length > 0
+      ? release.url
+      : `${REPO_URL}/releases/tag/${expectedTag}`;
+
+  // Idempotency: bail if this build is already documented.
+  const duplicateBuildRegex = new RegExp(
+    `^### \\[\\*\\*Build ${escapeRegExp(version)}\\*\\*\\]`,
+    'm'
+  );
+
+  if (duplicateBuildRegex.test(existingContent)) {
+    console.log(`Build ${version} already exists in ${target}. Skipping.`);
+    return;
+  }
+
+  const categories = parseReleaseBody(body);
+
+  if (categories.length === 0) {
+    throw new Error(
+      `No bullets parsed from release body for v${version}.\n` +
+        `The upstream release body format may have changed. Review manually:\n${body.slice(0, 500)}`
+    );
+  }
+
+  const changelogBlock = buildChangelogBlock(version, tagUrl, categories);
+
+  const [major, minorPart] = version.split('.');
+  const minor = `${major}.${minorPart}`;
+
+  // Locate the "## Release vX.Y" minor section for this build.
+  const sectionRegex = new RegExp(`^## Release v${escapeRegExp(minor)}\\+?\\s*$`, 'm');
+  const sectionMatch = existingContent.match(sectionRegex);
+
+  let updated;
+
+  if (sectionMatch && sectionMatch.index !== undefined) {
+    // Existing minor section: insert the build block at the top of its build
+    // list, after the editorial content and before the first existing build.
+    const sectionStart = sectionMatch.index + sectionMatch[0].length;
+    const rest = existingContent.slice(sectionStart);
+
+    const firstBuildInSection = rest.search(/^### \[\*\*Build /m);
+    const nextMinorSection = rest.search(/^## Release v/m);
+
+    let insertOffset;
+
+    if (
+      firstBuildInSection !== -1 &&
+      (nextMinorSection === -1 || firstBuildInSection < nextMinorSection)
+    ) {
+      // Insert just before the first build in this section.
+      insertOffset = sectionStart + firstBuildInSection;
+      const insertText = `${changelogBlock}\n`;
+      updated =
+        existingContent.slice(0, insertOffset) + insertText + existingContent.slice(insertOffset);
+    } else {
+      // Section has editorial content but no builds yet (or the next thing is a
+      // new minor section). Insert right after the editorial content.
+      insertOffset = nextMinorSection !== -1 ? sectionStart + nextMinorSection : existingContent.length;
+      const insertText = `\n${changelogBlock}\n`;
+      updated =
+        existingContent.slice(0, insertOffset) + insertText + existingContent.slice(insertOffset);
+    }
+
+    console.log(`Inserted Build ${version} into existing "## Release v${minor}" section.`);
+  } else {
+    // New minor: scaffold a stub section at the top, before the newest existing
+    // "## Release v" heading.
+    const firstSectionIndex = existingContent.search(/^## Release v/m);
+
+    if (firstSectionIndex === -1) {
+      throw new Error(`Could not find any "## Release v" section in ${target} to anchor the new minor section.`);
+    }
+
+    const stubSection = buildStubMinorSection(minor, version, changelogBlock, maintenances);
+    updated =
+      existingContent.slice(0, firstSectionIndex) +
+      `${stubSection}\n\n` +
+      existingContent.slice(firstSectionIndex);
+
+    console.log(
+      `Created stub "## Release v${minor}" section for new minor release and inserted Build ${version}. ` +
+        `Mainnet/testnet dates pulled from the status page when available; release highlights are left TODO for manual completion.`
+    );
+  }
+
+  writeFile(target, updated);
+
+  const totalBullets = categories.reduce((sum, category) => sum + category.bullets.length, 0);
+  console.log(
+    `Wrote Build ${version} to ${target} (${totalBullets} bullets across ${categories.length} categories).`
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/.github/scripts/select-backfill-versions.js
+++ b/.github/scripts/select-backfill-versions.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Determines which upstream releases are missing from a release-notes page.
+// Prints the missing stable versions newer than the latest documented one,
+// oldest-first, one per line. The caller adds them in that order so the newest
+// ends up at the top of the page.
+//
+// Works for both page styles:
+//   - mirror node:    "## [v0.155.1](...)"
+//   - consensus node: "### [**Build 0.74.0**](...)"
+//
+// Usage:
+// node select-backfill-versions.js --target path/to/notes.mdx --releases releases.json
+//
+// releases.json is the output of:
+//   gh release list --repo <repo> --exclude-pre-releases --exclude-drafts --json tagName
+
+'use strict';
+
+const fs = require('fs');
+
+// Matches the newest documented version in either heading style.
+const HEADING_REGEX = /^(?:## \[v|### \[\*\*Build )(\d+\.\d+\.\d+)\b/m;
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+
+    if (!key || !key.startsWith('--')) {
+      throw new Error(`Invalid argument "${key || ''}". Expected --key value.`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for argument "${key}".`);
+    }
+
+    parsed[key.slice(2)] = value;
+  }
+
+  return parsed;
+}
+
+function normalizeVersion(tag) {
+  return String(tag || '').trim().replace(/^v/i, '');
+}
+
+// Only stable X.Y.Z releases — drop anything with a prerelease suffix.
+function isStable(version) {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+
+  return 0;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const target = args.target;
+  const releasesPath = args.releases;
+
+  if (!target || !releasesPath) {
+    throw new Error(
+      'Usage: node select-backfill-versions.js --target path/to/notes.mdx --releases releases.json'
+    );
+  }
+
+  const content = fs.readFileSync(target, 'utf8');
+
+  // The latest documented version is the first version heading on the page.
+  const headingMatch = content.match(HEADING_REGEX);
+  if (!headingMatch) {
+    throw new Error(`Could not find a documented version heading in ${target}.`);
+  }
+  const documentedLatest = headingMatch[1];
+
+  let releases;
+  try {
+    releases = JSON.parse(fs.readFileSync(releasesPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not parse releases JSON from "${releasesPath}": ${error.message}`);
+  }
+
+  if (!Array.isArray(releases)) {
+    throw new Error(`Expected releases JSON to be an array, got ${typeof releases}.`);
+  }
+
+  const missing = releases
+    .map(release => normalizeVersion(release.tagName))
+    .filter(isStable)
+    .filter(version => compareVersions(version, documentedLatest) > 0)
+    .sort(compareVersions); // oldest first
+
+  for (const version of missing) {
+    console.log(version);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/.github/workflows/consensus-node-release-notes.yml
+++ b/.github/workflows/consensus-node-release-notes.yml
@@ -1,0 +1,152 @@
+name: Consensus Node Release Notes
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'A specific version to add (e.g. 0.74.1). Leave blank to backfill every missing release.'
+        required: false
+        type: string
+  schedule:
+    # Daily at 07:15 UTC. Safety net in case no push to main happened that day.
+    - cron: '15 7 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TARGET: learn/release-notes/services.mdx
+  REPO: hiero-ledger/hiero-consensus-node
+
+jobs:
+  add-release-notes:
+    runs-on: hashgraph-docs-linux-medium
+
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout docs repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '22'
+
+      - name: Plan versions to add
+        id: plan
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${VERSION_INPUT}" ]]; then
+            # Single-version mode: validate and use exactly the requested version.
+            VERSION="${VERSION_INPUT#v}"
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid version: ${VERSION_INPUT}" >&2
+              echo "Expected X.Y.Z or vX.Y.Z, for example 0.74.1 or v0.74.1." >&2
+              exit 1
+            fi
+            echo "$VERSION" > "$RUNNER_TEMP/versions.txt"
+          else
+            # Backfill mode: every stable release newer than the latest on the page.
+            gh release list \
+              --repo "$REPO" \
+              --exclude-pre-releases \
+              --exclude-drafts \
+              --limit 100 \
+              --json tagName \
+              > "$RUNNER_TEMP/releases.json"
+
+            node .github/scripts/select-backfill-versions.js \
+              --target "$TARGET" \
+              --releases "$RUNNER_TEMP/releases.json" \
+              > "$RUNNER_TEMP/versions.txt"
+          fi
+
+          COUNT="$(grep -c . "$RUNNER_TEMP/versions.txt" || true)"
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No missing releases — nothing to do."
+          else
+            echo "Will add $COUNT release(s):"
+            cat "$RUNNER_TEMP/versions.txt"
+            CSV="$(sed 's/^/v/' "$RUNNER_TEMP/versions.txt" | paste -sd, -)"
+            echo "versions_csv=${CSV}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate MDX entries
+        if: steps.plan.outputs.count != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Pull network upgrade dates from the Hedera status page (used to fill
+          # in mainnet/testnet dates when scaffolding a new minor section).
+          # Non-fatal: the script falls back to TODO dates if this is missing.
+          curl -sSfL --max-time 30 \
+            https://status.hedera.com/api/v2/scheduled-maintenances.json \
+            > "$RUNNER_TEMP/status.json" || echo '{}' > "$RUNNER_TEMP/status.json"
+
+          # Oldest-first so the newest release ends up prepended last (on top).
+          while IFS= read -r VERSION; do
+            [[ -z "$VERSION" ]] && continue
+            echo "::group::v${VERSION}"
+            gh release view "v${VERSION}" \
+              --repo "$REPO" \
+              --json body,tagName,url \
+              > "$RUNNER_TEMP/release.json"
+
+            node .github/scripts/consensus-node-release-entry.js \
+              --version "$VERSION" \
+              --release-json "$RUNNER_TEMP/release.json" \
+              --target "$TARGET" \
+              --status-json "$RUNNER_TEMP/status.json"
+            echo "::endgroup::"
+          done < "$RUNNER_TEMP/versions.txt"
+
+      - name: Open pull request
+        if: steps.plan.outputs.count != '0'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: learn/release-notes/services.mdx
+          commit-message: "docs: add consensus node release notes (${{ steps.plan.outputs.versions_csv }})"
+          signoff: true
+          sign-commits: true
+          branch: automation/consensus-node-release-notes
+          title: "docs: consensus node release notes (${{ steps.plan.outputs.versions_csv }})"
+          assignees: ${{ github.actor }}
+          labels: automated-pr
+          delete-branch: true
+          body: |
+            ## Consensus Node Release Notes
+
+            This PR adds the build changelog for the following consensus node releases: **${{ steps.plan.outputs.versions_csv }}**
+
+            Source: https://github.com/hiero-ledger/hiero-consensus-node/releases
+
+            ### Review checklist
+
+            - [ ] Verify bullets are accurate and complete
+            - [ ] For any new minor release, fill in the scaffolded `## Release vX.Y` release highlights + "What's new" accordion
+            - [ ] Confirm the auto-filled mainnet/testnet dates are correct (or fill any left as TODO if the status page had no date yet)
+            - [ ] Confirm each build block landed under the correct minor section, in descending order
+            - [ ] Check for breaking changes that warrant a callout

--- a/.github/workflows/consensus-node-release-notes.yml
+++ b/.github/workflows/consensus-node-release-notes.yml
@@ -56,38 +56,38 @@ jobs:
           if [[ -n "${VERSION_INPUT}" ]]; then
             # Single-version mode: validate and use exactly the requested version.
             VERSION="${VERSION_INPUT#v}"
-            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
               echo "Invalid version: ${VERSION_INPUT}" >&2
               echo "Expected X.Y.Z or vX.Y.Z, for example 0.74.1 or v0.74.1." >&2
               exit 1
             fi
-            echo "$VERSION" > "$RUNNER_TEMP/versions.txt"
+            echo "${VERSION}" > "${RUNNER_TEMP}/versions.txt"
           else
             # Backfill mode: every stable release newer than the latest on the page.
             gh release list \
-              --repo "$REPO" \
+              --repo "${REPO}" \
               --exclude-pre-releases \
               --exclude-drafts \
               --limit 100 \
               --json tagName \
-              > "$RUNNER_TEMP/releases.json"
+              > "${RUNNER_TEMP}/releases.json"
 
             node .github/scripts/select-backfill-versions.js \
-              --target "$TARGET" \
-              --releases "$RUNNER_TEMP/releases.json" \
-              > "$RUNNER_TEMP/versions.txt"
+              --target "${TARGET}" \
+              --releases "${RUNNER_TEMP}/releases.json" \
+              > "${RUNNER_TEMP}/versions.txt"
           fi
 
-          COUNT="$(grep -c . "$RUNNER_TEMP/versions.txt" || true)"
-          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          COUNT="$(grep -c . "${RUNNER_TEMP}/versions.txt" || true)"
+          echo "count=${COUNT}" >> "${GITHUB_OUTPUT}"
 
-          if [[ "$COUNT" -eq 0 ]]; then
+          if [[ "${COUNT}" -eq 0 ]]; then
             echo "No missing releases — nothing to do."
           else
             echo "Will add $COUNT release(s):"
-            cat "$RUNNER_TEMP/versions.txt"
+            cat "${RUNNER_TEMP}/versions.txt"
             CSV="$(sed 's/^/v/' "$RUNNER_TEMP/versions.txt" | paste -sd, -)"
-            echo "versions_csv=${CSV}" >> "$GITHUB_OUTPUT"
+            echo "versions_csv=${CSV}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Generate MDX entries
@@ -103,24 +103,24 @@ jobs:
           # Non-fatal: the script falls back to TODO dates if this is missing.
           curl -sSfL --max-time 30 \
             https://status.hedera.com/api/v2/scheduled-maintenances.json \
-            > "$RUNNER_TEMP/status.json" || echo '{}' > "$RUNNER_TEMP/status.json"
+            > "${RUNNER_TEMP}/status.json" || echo '{}' > "${RUNNER_TEMP}/status.json"
 
           # Oldest-first so the newest release ends up prepended last (on top).
           while IFS= read -r VERSION; do
-            [[ -z "$VERSION" ]] && continue
+            [[ -z "${VERSION}" ]] && continue
             echo "::group::v${VERSION}"
             gh release view "v${VERSION}" \
-              --repo "$REPO" \
+              --repo "${REPO}" \
               --json body,tagName,url \
-              > "$RUNNER_TEMP/release.json"
+              > "${RUNNER_TEMP}/release.json"
 
             node .github/scripts/consensus-node-release-entry.js \
-              --version "$VERSION" \
-              --release-json "$RUNNER_TEMP/release.json" \
-              --target "$TARGET" \
-              --status-json "$RUNNER_TEMP/status.json"
+              --version "${VERSION}" \
+              --release-json "${RUNNER_TEMP}/release.json" \
+              --target "${TARGET}" \
+              --status-json "${RUNNER_TEMP}/status.json"
             echo "::endgroup::"
-          done < "$RUNNER_TEMP/versions.txt"
+          done < "${RUNNER_TEMP}/versions.txt"
 
       - name: Open pull request
         if: steps.plan.outputs.count != '0'
@@ -150,3 +150,4 @@ jobs:
             - [ ] Confirm the auto-filled mainnet/testnet dates are correct (or fill any left as TODO if the status page had no date yet)
             - [ ] Confirm each build block landed under the correct minor section, in descending order
             - [ ] Check for breaking changes that warrant a callout
+


### PR DESCRIPTION
## summary

adds automation that keeps the consensus node release notes (`learn/release-notes/services.mdx`) up to date from the upstream `hiero-ledger/hiero-consensus-node` releases, mirroring the mirror-node automation and adapted to the consensus page's nested format.

on a new release it generates the build changelog block, inserts it under the correct `## release vX.Y` minor section (or scaffolds a new minor section), and opens a PR for review.

fixes #71 #73 

## what it does

- **triggers** - push to `main`, daily schedule (07:15 UTC safety net), and manual dispatch.
- **backfill (default)** - a blank/scheduled run finds every stable release newer than the latest on the page and adds them all in one PR, newest on top. pre-releases (`-rc`) and drafts are excluded.
- **single version** - dispatch with a version (e.g. `0.74.1`) to add just that one.
- **build block** - `### [**Build X.Y.Z**]` + `what's changed` accordion with `### **category**` subheadings, PR + author links, and the `full release notes` footer. matches the hand-authored format (verified byte-identical when regenerating `v0.74.0`).
- **new minor sections** - when a release introduces a new minor, scaffolds the `## release vX.Y` section and pulls mainnet/testnet upgrade dates from the hedera status page (`status.hedera.com/api/v2/scheduled-maintenances.json`): `<Check>`/UPDATED for completed upgrades, `<Info>`/UPDATE for upcoming, falling back to TODO only when the status page has no date yet. release highlights + "what's new" accordion are left as a TODO for editorial prose.
- **idempotent** - builds already on the page are skipped, so reruns and the daily schedule never duplicate.
- PRs are opened with DCO sign-off, labeled `automated-pr`, and assigned to the triggering actor.

## files

- `.github/workflows/consensus-node-release-notes.yml` - the workflow
- `.github/scripts/consensus-node-release-entry.js` - generates/inserts the build block
- `.github/scripts/select-backfill-versions.js` - lists releases missing from the page

## notes

- the workflow only opens a PR; nothing is auto-merged. the PR body includes a review checklist (verify bullets, fill in highlights, confirm dates, check ordering).
- reviewers still own the editorial parts: release highlights, the "what's new" accordion, and any breaking-change callouts.
- actions pinned to checkout v5.0.1 / setup-node v5.0.0 (node24 runtime) ahead of github's 2026 node 24 migration; the rest of the repo is still on v4.

## follow-up
- the companion mirror-node automation is in #634 .
