### PR TITLE
docs: add Faucet API page for programmatic testnet HBAR

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2125,6 +2125,7 @@
               "learn/getting-started/why-hedera",
               "learn/getting-started/choose-your-path",
               "learn/getting-started/testnet-faucet",
+              "learn/getting-started/faucet-api",
               "learn/getting-started/portal-playground"
             ]
           },

--- a/learn/getting-started/faucet-api.mdx
+++ b/learn/getting-started/faucet-api.mdx
@@ -4,9 +4,7 @@ description: "Fund testnet and previewnet accounts with HBAR programmatically ov
 icon: "terminal"
 ---
 
-The Hedera Portal faucet exposes an HTTP endpoint so you can fund Hedera accounts programmatically, with no browser, no reCAPTCHA, and no copy-pasting addresses into a web form.
-
-The Faucet API supports funding accounts from the terminal, scripts, CI/CD pipelines, SDKs, or agentic workflows.
+The Hedera Portal exposes an HTTP faucet endpoint so you can fund testnet and previewnet accounts programmatically from the terminal, scripts, CI/CD pipelines, SDKs, or agentic workflows, with no browser, no reCAPTCHA, and no copy-pasting.
 
 <Info>
 	For a one-off, the [web faucet](/learn/getting-started/testnet-faucet) at [portal.hedera.com](https://portal.hedera.com/faucet) is the simplest
@@ -45,6 +43,11 @@ $env:HEDERA_PAT = "<your-personal-access-token>"
 
 Send a `POST` to `/api/disbursement/cli` with your PAT as a Bearer token.
 
+<Info>
+	**About the destination:** A Hedera account ID (`0.0.x`) must already exist on the network. An EVM address that has no account yet gets one created
+	on the spot through [auto account creation](/learn/core-concepts/accounts/auto-account-creation) when the HBAR lands.
+</Info>
+
 ```bash wrap
 curl -X POST https://portal.hedera.com/api/disbursement/cli \
   -H "Authorization: Bearer $HEDERA_PAT" \
@@ -65,11 +68,6 @@ curl -X POST https://portal.hedera.com/api/disbursement/cli \
 | `network`    | No       | `testnet` (default) or `previewnet`.                                                        |
 | `sdkVersion` | No       | For tool authors: the SDK version, so usage can be attributed.                              |
 | `cliVersion` | No       | For tool authors: the CLI version.                                                          |
-
-<Info>
-	**About the destination:** A Hedera account ID (`0.0.x`) must already exist on the network. An EVM address that has no account yet gets one created
-	on the spot through [auto account creation](/learn/core-concepts/accounts/auto-account-creation) when the HBAR lands.
-</Info>
 
 ---
 

--- a/learn/getting-started/faucet-api.mdx
+++ b/learn/getting-started/faucet-api.mdx
@@ -1,0 +1,131 @@
+---
+title: "Faucet API"
+description: "Fund testnet and previewnet accounts with HBAR programmatically over HTTP, no browser required."
+icon: "terminal"
+---
+
+The Hedera Portal faucet exposes an HTTP endpoint so you can fund Hedera accounts programmatically, with no browser, no reCAPTCHA, and no copy-pasting addresses into a web form.
+
+The Faucet API supports funding accounts from the terminal, scripts, CI/CD pipelines, SDKs, or agentic workflows.
+
+<Info>
+	For a one-off, the [web faucet](/learn/getting-started/testnet-faucet) at [portal.hedera.com](https://portal.hedera.com/faucet) is the simplest
+	path. Use the Faucet API when you want to fund accounts programmatically or in bulk.
+</Info>
+
+<Note>
+	**Need mainnet HBAR?** This Portal Faucet API serves **testnet and previewnet** only. For mainnet, the ecosystem project HashPort runs a
+	community-operated [Faucet API](https://faucet.hashport.network/) that distributes HBAR to onboard new users.
+</Note>
+
+---
+
+## Before you start
+
+The Faucet API requires a Hedera Portal account and a Personal Access Token (the web faucet does not):
+
+1. **A Hedera Portal account.** [Sign up](https://portal.hedera.com/register) if you don't have one.
+2. **A Personal Access Token (PAT).** Generate one from the Portal UI, following [Create an API Key](/native/tutorials/getting-started/create-api-key).
+
+In your terminal, set your token as an environment variable so the `curl` examples below can read it. The `export` command runs in a macOS or Linux shell (bash or zsh) and lasts for the current terminal session:
+
+```bash
+export HEDERA_PAT="<your-personal-access-token>"
+```
+
+On Windows PowerShell, use:
+
+```powershell
+$env:HEDERA_PAT = "<your-personal-access-token>"
+```
+
+---
+
+## Make a request
+
+Send a `POST` to `/api/disbursement/cli` with your PAT as a Bearer token.
+
+```bash wrap
+curl -X POST https://portal.hedera.com/api/disbursement/cli \
+  -H "Authorization: Bearer $HEDERA_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "address": "0.0.12345",
+    "amount": 25,
+    "network": "testnet"
+  }'
+```
+
+### Request fields
+
+| Field        | Required | Description                                                                                 |
+| ------------ | -------- | ------------------------------------------------------------------------------------------- |
+| `address`    | Yes      | The destination: a Hedera account ID (`0.0.12345`) or an EVM address (`0x…`, 40 hex chars). |
+| `amount`     | Yes      | A whole number of HBAR to send, from `1` to `100`.                                          |
+| `network`    | No       | `testnet` (default) or `previewnet`.                                                        |
+| `sdkVersion` | No       | For tool authors: the SDK version, so usage can be attributed.                              |
+| `cliVersion` | No       | For tool authors: the CLI version.                                                          |
+
+<Info>
+	**About the destination:** A Hedera account ID (`0.0.x`) must already exist on the network. An EVM address that has no account yet gets one created
+	on the spot through [auto account creation](/learn/core-concepts/accounts/auto-account-creation) when the HBAR lands.
+</Info>
+
+---
+
+## Response
+
+A successful request returns the amount sent, the on-chain transaction ID, and your remaining daily allowance:
+
+```json
+{
+	"amount": 25,
+	"transactionId": "0.0.2@1715600000.123456789",
+	"dailyQuota": {
+		"used": 25,
+		"remaining": 75
+	}
+}
+```
+
+- **`amount`**: how much HBAR was actually sent.
+- **`transactionId`**: the on-chain transaction ID. Use it to look up the transfer on a [mirror node](/reference/rest-api) or [HashScan](https://hashscan.io).
+- **`dailyQuota`**: `used` and `remaining` HBAR in your rolling 24-hour window.
+
+---
+
+## Limits
+
+Three limits apply to every request, and a call must satisfy all three:
+
+- **Up to 100 HBAR per call.**
+- **Up to 100 HBAR per 24 hours**, as a rolling window tied to your Hedera Portal account.
+- **One funding per destination account per 24 hours.** This cooldown is shared with the web faucet, so if an account was funded on the web today, the API will refuse it for the next 24 hours, and vice versa.
+
+A few things to know:
+
+- You can spread your daily 100 HBAR across multiple accounts (for example, 10 HBAR to each of 10 accounts).
+- You can hit your daily cap while fresh destinations are still available, in which case you'll need to wait for the window to roll off.
+- You can hit a destination's cooldown while you still have HBAR left, so switch to another account.
+
+---
+
+## Troubleshooting
+
+The faucet uses standard HTTP status codes:
+
+| Status                      | What it means                                                                                                               | How to fix it                                                                                             |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `400 Bad Request`           | Your request body didn't pass validation, for example `amount` is missing or outside `1` to `100`, or `network` is invalid. | Check the request body against the [request fields](#request-fields).                                     |
+| `403 Forbidden`             | Your token is missing, malformed, or has been revoked.                                                                      | Verify the `Authorization` header reads `Bearer <token>`, and that the token still exists in the Portal.  |
+| `422 Unprocessable Entity`  | The destination can't be funded: the account ID does not exist, address is invalid, or it was funded in the last 24 hours.  | Confirm the account exists or the address is well-formed, and off cooldown, or fund a different account.  |
+| `429 Too Many Requests`     | You've used your full 100 HBAR for the last 24 hours.                                                                       | Wait for your 24-hour window to roll off, then try again.                                                 |
+| `500 Internal Server Error` | The transfer failed on the server side.                                                                                     | Retry after a minute. If it persists, check the transaction ID on a mirror node and reach out to support. |
+
+---
+
+## Next steps
+
+- [Create an API Key (PAT)](/native/tutorials/getting-started/create-api-key): required to authenticate Faucet API requests.
+- [Web Testnet Faucet](/learn/getting-started/testnet-faucet): create and fund an account from the browser.
+- [Learn more about accounts](/learn/core-concepts/accounts)

--- a/learn/getting-started/testnet-faucet.mdx
+++ b/learn/getting-started/testnet-faucet.mdx
@@ -5,6 +5,10 @@ icon: "faucet"
 
 The Hedera faucet allows you to quickly create and fund a testnet account without creating a developer portal account. The faucet flow auto-creates an account when you enter an EVM wallet address to receive testnet HBAR.
 
+<Info>
+Prefer the terminal? The [Faucet API](/learn/getting-started/faucet-api) funds testnet and previewnet accounts programmatically, ideal for scripts, CI pipelines, and agentic workflows.
+</Info>
+
 <Steps>
 <Step title="Step 1: Visit the faucet">
 

--- a/native/tutorials/getting-started/create-api-key.mdx
+++ b/native/tutorials/getting-started/create-api-key.mdx
@@ -5,6 +5,10 @@ sidebarTitle: "Create an API Key"
 
 In the Hedera Portal, the Personal Access Token (API key) is a new feature for seamless application development and management. This feature facilitates the process of account recreation and querying for account ID after a test network (Testnet or Previewnet) resets. Whenever the testnet is reset, developers have to manually log in to the portal, recreate an account, get the account ID, and input the new account ID into their development environment. Utilizing this new feature to generate an API key eliminates the need to manually recreate accounts. There are no prerequisites for this tutorial.
 
+<Info>
+The Personal Access Token you create here also authenticates [Faucet API](/learn/getting-started/faucet-api) requests, letting you fund testnet and previewnet accounts programmatically from your terminal.
+</Info>
+
 ---
 
 **By the end of this tutorial, you will know how to:**


### PR DESCRIPTION
  ## Description

  Adds a new **Faucet API** page documenting the Hedera Portal's programmatic HBAR disbursement endpoint (`POST /api/disbursement/cli`), which lets developers fund testnet and previewnet accounts from the
  terminal, scripts, CI/CD pipelines, SDKs, and agentic workflows without using the web faucet UI.

  ## Changes

  - **New page:** `learn/getting-started/faucet-api.mdx` — prerequisites (Portal account + PAT), request/response reference, user-facing rate limits, troubleshooting by HTTP status code, and a note pointing
  mainnet users to HashPort's community-operated faucet
  - **Navigation:** added the page to the Getting Started group in `docs.json`, after the web faucet
  - **Cross-links:** callouts on `learn/getting-started/testnet-faucet.mdx` and `native/tutorials/getting-started/create-api-key.mdx` pointing to the new page

  ## Checklist

  - [x] `mint broken-links` passes
  - [x] Page renders correctly in local preview (`mint dev`) and appears in the sidebar
  - [x] In-body links use absolute new-structure paths (no legacy paths)
  - [x] No redirect changes needed (new page, not a move/rename)
  - [x] Commits are DCO signed (`-s`) and GPG signed (`-S`)