### PR TITLE
chore: update CODEOWNERS for README and .gitignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,12 +16,12 @@
 /CODEOWNERS                                             @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                              @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-docs
+/README.md                                              @hashgraph/hedera-docs @hashgraph/hedera-docs-committers
 **/LICENSE                                              @hashgraph/release-engineering-managers
 
 # CodeCov configuration
 **/codecov.yml                                          @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-docs
 
 # Git Ignore definitions
-**/.gitignore                                           @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-docs
-**/.gitignore.*                                         @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-docs
+**/.gitignore                                           @hashgraph/hedera-docs @hashgraph/hedera-docs-committers
+**/.gitignore.*                                         @hashgraph/hedera-docs @hashgraph/hedera-docs-committers


### PR DESCRIPTION
## update codeowners: make readme and .gitignore docs-owned

| path | before | after |
| -- | -- | -- |
| /README.md | platform-ci, release-engineering, hedera-docs | hedera-docs, hedera-docs-committers |
| **/.gitignore | platform-ci, release-engineering, hedera-docs | hedera-docs, hedera-docs-committers |
| **/.gitignore.* | platform-ci, release-engineering, hedera-docs | hedera-docs, hedera-docs-committers |

## why

this is a docs content repo. the readme and .gitignore don't touch ci, secrets, or releases, so requiring platform-ci / release-engineering approval just adds latency to routine docs prs. the docs teams already own everything by default (line 2)

### **not changed**

`.github/workflows/`, `.github/CODEOWNERS`, and `/.github/ `keep their platform-ci / release-engineering ownership. those control ci execution and deploys


**reviewers:** per line 13, merging this requires platform-ci / release-engineering approval. flagging so it's not left waiting.

**fixes**: #647 