### PR TITLE
fix: correct setCustomFeeLimits method name in submit-message docs

### DIFF
--- a/native/consensus/submit-message.mdx
+++ b/native/consensus/submit-message.mdx
@@ -16,15 +16,15 @@ The **max chunk size** refers to the maximum size (in bytes) of each individual 
 
 ## **Custom Fee Payment**
 
-If a topic has custom fees enabled, users submitting messages must pay the required fee in **HBAR or HTS fungible tokens**. If `setCustomFees` is not specified in the transaction, the user would need to pay any fee associated with that topic ID. The transaction will only fail if the user does not have sufficient assets to cover the fee.
+If a topic has custom fees enabled, users submitting messages must pay the required fee in **HBAR or HTS fungible tokens**. If `setCustomFeeLimits` is not specified in the transaction, the user would need to pay any fee associated with that topic ID. The transaction will only fail if the user does not have sufficient assets to cover the fee.
 
-**Recommendation:** To avoid unexpected fees, it is strongly recommended to use `setCustomFees` when submitting a message. This ensures that only the intended fee structure is applied, providing a safeguard against unintended charges.
+**Recommendation:** To avoid unexpected fees, it is strongly recommended to use `setCustomFeeLimits` when submitting a message. This ensures that only the intended fee structure is applied, providing a safeguard against unintended charges.
 
 ```java
 TopicMessageSubmitTransaction()
    .setTopicId(<TOPIC_ID>)
    .setMessage(<MESSAGE>)
-   .setCustomFees(<MAX_CUSTOM_FEES>) // Ensure this covers the required amount
+   .setCustomFeeLimits(<CUSTOM_FEE_LIMITS>) // Ensure this covers the required amount
    .execute(client);
 ```
 
@@ -38,7 +38,7 @@ TopicMessageSubmitTransaction()
 - Each transaction incurs a standard Hedera network fee based on network resource usage.
 - If a custom fee is set for a topic, users submitting messages must pay this fee in HBAR or HTS tokens.
 - The Fee Schedule Key allows authorized users to update fee structures. If set, it must sign transactions modifying fees.
-- If the topic has custom fees, the sender must have sufficient balance to cover the fees unless they are exempt via the Fee Exempt Key List. It is recommended to use `setCustomFees` on the `TopicMessageSubmitTransaction` to ensure the expected fee structure is applied and avoid unexpected transaction failures due to insufficient funds.
+- If the topic has custom fees, the sender must have sufficient balance to cover the fees unless they are exempt via the Fee Exempt Key List. It is recommended to use `setCustomFeeLimits` on the `TopicMessageSubmitTransaction` to ensure the expected fee structure is applied and avoid unexpected transaction failures due to insufficient funds.
 - If you submit a message to a topic with a custom fee, the cost changes from the baseline $0.0001 USD to roughly $0.05 USD per `TopicMessageSubmitTransaction`.
 - Use the [query fees table](/learn/networks/mainnet/fees#consensus-service) for the base transaction fee and the [Hedera Fee Estimator](https://hedera.com/fees) to estimate standard network fees.
 
@@ -133,7 +133,7 @@ TopicMessageSubmitTransaction()
 TopicMessageSubmitTransaction transaction = new TopicMessageSubmitTransaction()
     .setTopicId(newTopicId)
     .setMessage("hello, HCS! ")
-    .setMaxCustomFees(maxCustomFees); // Set max custom fees if applicable
+    .setCustomFeeLimits(maxCustomFees); // Set custom fee limits if applicable
 
 //Sign with the client operator key and submit transaction to a Hedera network, get transaction ID
 TransactionResponse txResponse = transaction.execute(client);
@@ -155,7 +155,7 @@ System.out.println("The transaction consensus status is " +transactionStatus);
 const transaction = await new TopicMessageSubmitTransaction()
   .setTopicId(newTopicId)
   .setMessage("Hello, HCS!")
-  .setMaxCustomFees(maxCustomFees); // Set max custom fees if applicable
+  .setCustomFeeLimits(maxCustomFees); // Set custom fee limits if applicable
 
 // Execute transaction
 const txResponse = await transaction.execute(client);
@@ -174,7 +174,7 @@ console.log("Transaction Status:", receipt.status);
 transaction := hedera.NewTopicSubmitTransaction().
         SetTopicID(topicID).
         SetMessage([]byte(content)).
-        SetMaxCustomFees(maxCustomFees) // Set max custom fees if applicable
+        SetCustomFeeLimits(maxCustomFees) // Set custom fee limits if applicable
 
 //Sign with the client operator private key and submit the transaction to a Hedera network
 txResponse, err := transaction.Execute(client)
@@ -201,7 +201,7 @@ fmt.Printf("The transaction consensus status is %v\n", transactionStatus)
 let transaction = TopicMessageSubmitTransaction::new()
     .topic_id(topic_id)
     .message("Hello, HCS!")
-    .max_custom_fees(max_custom_fees); // Set max custom fees if applicable
+    .custom_fee_limits(max_custom_fees); // Set custom fee limits if applicable
 
 // Sign with the client operator key and submit to a Hedera network
 let tx_response = transaction.execute(&client).await?;


### PR DESCRIPTION
fixes the custom-fee method name in the "submit a message" docs. the page used
`setMaxCustomFees` / `setCustomFees`, neither of which exists on
`TopicMessageSubmitTransaction`. the correct method is `setCustomFeeLimits`.

resolves #104.

## changes

`native/consensus/submit-message.mdx` — updated prose, the transaction fees
bullet, and the java/javascript/go/rust code samples to use the
language-idiomatic `setCustomFeeLimits`.

## verification

confirmed against sdk source (`main`): java `setCustomFeeLimits`, js
`setCustomFeeLimits`, go `SetCustomFeeLimits`, rust `custom_fee_limits`.
`setMaxCustomFees` exists in none of them.