### PR TITLE
fix: set mainnet mirror node as default API server URL

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -28,6 +28,9 @@
     "decoration": "gradient"
   },
   "favicon": "/favicon.png",
+  "api": {
+    "baseUrl": "https://mainnet.mirrornode.hedera.com"
+  },
   "appearance": {
     "default": "light"
   },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1522,8 +1522,8 @@ externalDocs:
   description: REST API Docs
   url: "https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api"
 servers:
-  - description: The current REST API server
-    url: ""
+  - description: Hedera Mainnet Mirror Node
+    url: "https://mainnet.mirrornode.hedera.com"
   - description: The production REST API servers
     url: "{scheme}://{network}.mirrornode.hedera.com"
     variables:


### PR DESCRIPTION
**Description**:
- sets https://mainnet.mirrornode.hedera.com as the default server in `openapi.yaml`, replacing the empty url: "" that caused Mintlify to fall back to api.example.com in curl examples and the try-it button
- adds `api.baseUrl` to `docs.json` as the persistent fix. this survives mint dev regenerating `openapi.yaml` on startup

**Related issue(s)**:

Fixes #659 

