### PR TITLE
docs: move MCP server setup page to learn/getting-started

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1981,7 +1981,11 @@
     },
     {
       "source": "/hedera/tutorials/more-tutorials/hedera-mcp-server-setup-guide",
-      "destination": "/native/tutorials/advanced/mcp-server-setup"
+      "destination": "/learn/getting-started/mcp-setup"
+    },
+    {
+      "source": "/native/tutorials/advanced/mcp-server-setup",
+      "destination": "/learn/getting-started/mcp-setup"
     },
     {
       "source": "/hedera/tutorials/more-tutorials/how-to-auto-create-hedera-accounts-with-hbar-and-token-transfers",
@@ -2165,7 +2169,8 @@
               "learn/getting-started/choose-your-path",
               "learn/getting-started/testnet-faucet",
               "learn/getting-started/faucet-api",
-              "learn/getting-started/portal-playground"
+              "learn/getting-started/portal-playground",
+              "learn/getting-started/mcp-setup"
             ]
           },
           {
@@ -2734,7 +2739,6 @@
                   "native/tutorials/advanced/javascript-testing",
                   "native/tutorials/advanced/walletconnect-dapp",
                   "native/tutorials/advanced/hashgraphdev",
-                  "native/tutorials/advanced/mcp-server-setup",
                   {
                     "group": "HSM Signing",
                     "pages": [

--- a/index.mdx
+++ b/index.mdx
@@ -314,7 +314,7 @@ import { PlaygroundShowcase } from '/snippets/showcases/playground-showcase.jsx'
 
   <div className="landing-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
 
-    <a href="/native/tutorials/advanced/mcp-server-setup" className="landing-card">
+    <a href="/learn/getting-started/mcp-setup" className="landing-card">
       <div className="landing-card-icon">
         <img src="/images/brand-icons/icon-white-ai-studio.svg" alt="" aria-hidden="true" />
       </div>

--- a/learn/getting-started/mcp-setup.mdx
+++ b/learn/getting-started/mcp-setup.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hedera Docs MCP Server Setup Guide
 sidebarTitle: "MCP Server Setup"
+icon: "robot"
 ---
 
 Connect your AI tools to the official Hedera documentation for real-time, accurate answers to your Hedera-related questions — directly from the source.
@@ -50,7 +51,7 @@ To connect, you manually add the server URL to your AI tool's configuration usin
 <Note>
 
 #### Note
-If you run into issues, refer to the [Additional Resources](/native/tutorials/advanced/mcp-server-setup#additional-resources) section below as setup instructions can change and that's where you'll find the most current guidance.
+If you run into issues, refer to the [Additional Resources](/learn/getting-started/mcp-setup#additional-resources) section below as setup instructions can change and that's where you'll find the most current guidance.
 
 </Note>
 

--- a/native/tutorials/more/index.mdx
+++ b/native/tutorials/more/index.mdx
@@ -47,7 +47,7 @@ title: More Tutorials
 
   <Card
     title="Hedera Docs MCP server setup guide"
-    href="/native/tutorials/advanced/mcp-server-setup"
+    href="/learn/getting-started/mcp-setup"
     arrow
     img="/images/tutorials/more-tutorials/more-tutorials.png">
     


### PR DESCRIPTION
**Description**:
moves the MCP server setup page from `native/tutorials/advanced` to `learn/getting-started` where it's actually discoverable. 

**Related issue(s)**:

Fixes #664 