### PR TITLE
docs: add Scaffold HBAR card to Solutions landing page

### DIFF
--- a/solutions/index.mdx
+++ b/solutions/index.mdx
@@ -183,6 +183,16 @@ mode: wide
       </div>
     </a>
 
+    <a href="/solutions/tools/scaffold-hbar/index" className="landing-card">
+      <div className="landing-card-icon">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z M2 17l10 5 10-5 M2 12l10 5 10-5"/></svg>
+      </div>
+      <div>
+        <div className="landing-card-title">Scaffold HBAR</div>
+        <div className="landing-card-desc">Scaffold Hedera dApps from the CLI—templates, contracts, Next.js, and Hedera Skills.</div>
+      </div>
+    </a>
+
     <a href="/solutions/tools/hiero-cli/overview" className="landing-card">
       <div className="landing-card-icon">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 17l6-6-6-6 M12 19h8"/></svg>


### PR DESCRIPTION
## Summary

Adds a **Scaffold HBAR** card to the [Solutions landing page](https://docs.hedera.com/solutions#developer-tools), linking to `/solutions/tools/scaffold-hbar/index`.

The docs page already exists in the sidebar; this makes it discoverable from the main Solutions overview, placed second after Developer Playground (matching nav order).

## Changes

- `solutions/index.mdx` — new Developer tools card for Scaffold HBAR

## Test plan

- [x] Local preview at `/solutions#developer-tools`
- [x] Card links to Scaffold HBAR docs page