### PR TITLE
fix: resolve ATS docs link errors + update outdated info

### DIFF
--- a/solutions/tokenization/ats/faq.mdx
+++ b/solutions/tokenization/ats/faq.mdx
@@ -55,7 +55,7 @@ Yes, ATS allows certain [updates to tokenized assets using proxy contracts](/sol
 
 <Accordion title="Does Asset Tokenization Studio Support ERC-3643 Compliance?">
 
-Yes, Asset Tokenization Studio supports optional integration with [ERC-3643](/support/glossary#erc-3643), a standard for permissioned tokens that enables compliance with securities regulations through on-chain compliance rules and identity verification. During bond or equity creation, issuers can configure ERC-3643 by specifying a Compliance ID (the smart contract enforcing regulatory rules) and an Identity Registry ID (the contract managing investor identities and compliance status). This integration allows ATS to work seamlessly with existing ERC-3643 compliance infrastructure for enhanced regulatory compliance.
+Yes, Asset Tokenization Studio includes partial [ERC-3643](/support/glossary#erc-3643) support by default. Full ERC-3643 integration is available as an optional configuration — during bond or equity creation, issuers can specify a Compliance ID (the smart contract enforcing regulatory rules) and an Identity Registry ID (the contract managing investor identities and compliance status) to work with existing ERC-3643 compliance infrastructure.
 </Accordion>
 
 <Accordion title="What Are External Management Lists and How Do They Work?">
@@ -66,6 +66,6 @@ External Management Lists in Asset Tokenization Studio allow issuers to integrat
 
 <Accordion title="What Wallets Are Supported by Asset Tokenization Studio?">
 
-Asset Tokenization Studio supports wallets compatible with the Hedera network, including [MetaMask](https://metamask.io/) and [HashPack](https://www.hashpack.app/). This allows users to easily interact with their tokenized assets through secure wallet integrations.
+Asset Tokenization Studio supports wallets compatible with the Hedera network, including [MetaMask](https://metamask.io/), [HashPack](https://www.hashpack.app/), and [Blade Wallet](https://bladelabs.io/). This allows users to easily interact with their tokenized assets through secure wallet integrations.
 </Accordion>
 </AccordionGroup>

--- a/solutions/tokenization/ats/index.mdx
+++ b/solutions/tokenization/ats/index.mdx
@@ -31,13 +31,20 @@ The tokenization process involves several key steps:
 
 By transforming asset ownership into digital form, tokenization paves the way for a more efficient and inclusive financial system, opening up new opportunities for investors and asset owners.
 
-➡️[Asset Tokenization Studio Source Code Repo](https://github.com/hashgraph/asset-tokenization-studio)
+<CardGroup cols={2}>
+  <Card title="ATS Source Code" icon="github" href="https://github.com/hashgraph/asset-tokenization-studio" arrow>
+    Open-source monorepo on GitHub — smart contracts, SDK, and Web UI source.
+  </Card>
+  <Card title="ATS Official Documentation" icon="book-open" href="https://docs.tokenization-studio.hedera.com/" arrow>
+    Full API references, guides, and integration documentation for Asset Tokenization Studio.
+  </Card>
+</CardGroup>
 
 ---
 
 ## Introducing Asset Tokenization Studio (ATS)
 
-To streamline and simplify the asset tokenization process, Asset Tokenization Studio (ATS)—Hedera's open-source platform that allows issuers to create, manage, and operate [digital securities](/support/glossary#digital-security) in [compliance](/support/glossary#compliance) with global regulations by adhering to the guidelines set forth by [SEC Regulations D](https://www.sec.gov/resources-for-investors/investor-alerts-bulletins/private-placements-under-regulation-d-investor-bulletin) ([506-b](https://www.sec.gov/resources-small-businesses/exempt-offerings/private-placements-rule-506b), [506-c](https://www.sec.gov/resources-small-businesses/exempt-offerings/general-solicitation-rule-506c)) and [Regulation S](https://www.sec.gov/rules-regulations/1998/02/offshore-offers-sales-regulation-s-effective-date-60-days-after-publication-federal-register). ATS makes asset tokenization accessible through the below key components and features that are open-source under an Apache 2.0 license, with the source code to be publicly available on GitHub soon:
+To streamline and simplify the asset tokenization process, Asset Tokenization Studio (ATS)—Hedera's open-source platform that allows issuers to create, manage, and operate [digital securities](/support/glossary#digital-security) in [compliance](/support/glossary#compliance) with global regulations by adhering to the guidelines set forth by [SEC Regulations D](https://www.sec.gov/resources-for-investors/investor-alerts-bulletins/private-placements-under-regulation-d-investor-bulletin) ([506-b](https://www.sec.gov/resources-small-businesses/exempt-offerings/private-placements-rule-506b), [506-c](https://www.sec.gov/resources-small-businesses/exempt-offerings/general-solicitation-rule-506c)) and [Regulation S](https://www.sec.gov/rules-regulations/1998/02/offshore-offers-sales-regulation-s-effective-date-60-days-after-publication-federal-register). ATS makes asset tokenization accessible through the below key components and features that are open-source under an Apache 2.0 license:
 
 <Columns cols={3}>
 <Card
@@ -47,9 +54,6 @@ To streamline and simplify the asset tokenization process, Asset Tokenization St
   img="/images/open-source-solutions/asset-tokenization-studio-ats/asset-tokenization-studio-ats-3.png"
 >
   A user-friendly web application that simplifies tokenization, making it accessible for developers and non-technical users to easily interact with digital securities.
-
-✅ Available
-
 </Card>
 <Card
   title="Customizable SDK"
@@ -58,29 +62,23 @@ To streamline and simplify the asset tokenization process, Asset Tokenization St
   img="/images/open-source-solutions/asset-tokenization-studio-ats/asset-tokenization-studio-ats-4.png"
 >
   A flexible open-source Software Development Kit (SDK) that enables developers to build custom tokenization solutions and deploy decentralized apps on the Hedera network.
-
-✅ Available
-
 </Card>
 
 <Card
   title="Smart Contracts"
-  href="https://github.com/hashgraph/asset-tokenization-studio/tree/main/contracts"
+  href="https://github.com/hashgraph/asset-tokenization-studio/tree/main/packages/ats/contracts"
   arrow
   img="/images/open-source-solutions/asset-tokenization-studio-ats/asset-tokenization-studio-ats-5.png"
 >
   Open-source, pre-built, and fully audited smart contracts that automate and standardize the tokenization process according to the <a href="https://github.com/ethereum/EIPs/issues/1411" target="_blank" rel="noopener noreferrer">ERC-1400</a> standard.
-
-✅ Available
-
 </Card>
 </Columns>
 
-Additional features include support for popular wallets, including [MetaMask](), [HashPack](), and [Blade Wallet](), and also extend the ERC-1400 standard by integrating additional modules to manage asset-specific metadata directly on the Hedera network. This includes functionalities like managing coupon payments or approval lists on-chain, enhancing transparency, and mitigating off-chain management risks.
+Additional features include support for popular wallets — [MetaMask](https://metamask.io/) connects directly, while [HashPack](https://www.hashpack.app/) and [Blade Wallet](https://bladelabs.io/) connect via Hedera WalletConnect 2.0 — and also extend the ERC-1400 standard by integrating additional modules to manage asset-specific metadata directly on the Hedera network. This includes functionalities like managing coupon payments or approval lists on-chain, enhancing transparency, and mitigating off-chain management risks.
 
 ## Ecosystem Integrations & Launch Partners
 
-ATS integrates with key partners like [RedSwan](https://redswan.io/), [ioBuilders](https://io.builders/), and [The Hedera Foundation](https://hedera.foundation/) to facilitate the issuance and management of tokenized bonds and equities on the Hedera network. These partners provide solutions for [KYC](/support/glossary#know-your-customer-kyc) [AML](/support/glossary#anti-money-laundering-aml) compliance, [custody](/support/glossary#custody), wallet integration, infrastructure management, [smart contract]() monitoring, and regulatory compliance.
+ATS integrates with key partners like [RedSwan](https://redswan.io/), [ioBuilders](https://io.builders/), and [The Hedera Foundation](https://hedera.foundation/) to facilitate the issuance and management of tokenized bonds and equities on the Hedera network. These partners provide solutions for [KYC](/support/glossary#know-your-customer-kyc) [AML](/support/glossary#anti-money-laundering-aml) compliance, [custody](/support/glossary#custody), wallet integration, infrastructure management, smart contract monitoring, and regulatory compliance.
 
 <Columns cols={3}>
   <Card
@@ -181,9 +179,7 @@ ATS integrates with key partners like [RedSwan](https://redswan.io/), [ioBuilder
     arrow
     img="/images/open-source-solutions/asset-tokenization-studio-ats/asset-tokenization-studio-ats-15.png"
   >
-    Dfns provides secure, API-driven custody solutions for digital assets,
-    ensuring that tokenized assets and transactions are protected with
-    military-grade encryption.
+    Dfns provides secure, API-driven custody solutions for digital assets. ATS also integrates with [Fireblocks](https://www.fireblocks.com/) and [AWS KMS](https://aws.amazon.com/kms/) for institutional and cloud-based key management signing.
   </Card>
   <Card
     title="Diamond Standard"
@@ -218,7 +214,7 @@ standard, which is interoperable with other key standards like [ERC-20](https://
 [ERC-1594](https://github.com/ethereum/eips/issues/1594),
 [ERC-1643](https://github.com/ethereum/eips/issues/1643),
 and [ERC-1644](https://github.com/ethereum/EIPs/issues/1644)
-to offer a comprehensive solution for managing [security tokens](/support/glossary#security-token). Additionally, ATS supports [ERC-3643](/support/glossary#erc-3643) integration for enhanced compliance and identity management through optional configuration of compliance smart contracts and identity registries. It
+to offer a comprehensive solution for managing [security tokens](/support/glossary#security-token). Additionally, ATS includes partial [ERC-3643](/support/glossary#erc-3643) support by default, with full integration available through optional configuration of compliance smart contracts and identity registries. It
 provides a comprehensive framework for managing [digital securities](/support/glossary#digital-security). The
 core implementation layer includes the following modules:
 
@@ -231,7 +227,7 @@ core implementation layer includes the following modules:
 | **Lock**           | The lock function freezes specific tokens or accounts, useful for restricted trading periods, legal holds, or tokens subject to vesting schedules or escrow.                                                                                                                                 |
 | **Snapshots**      | Snapshots capture token holder balances at any given time, providing accurate records for audits, dividends, or voting rights, ensuring compliance with corporate actions.                                                                                                                   |
 
-These modules provide a solid framework for efficient and compliant token management. ATS also supports integration with external management lists, including external pause contracts, control contracts, and [KYC](/support/glossary#know-your-customer-kyc) verification providers for enhanced security and compliance. Future module enhancements, such as Protected Partitions, will further enhance security and compliance capabilities.
+These modules provide a solid framework for efficient and compliant token management. ATS also supports integration with external management lists, including external pause contracts, control contracts, and [KYC](/support/glossary#know-your-customer-kyc) verification providers for enhanced security and compliance.
 <Accordion title="📚 Learn more about ERC-1400 ⬇">
 
 [**ERC-1400**](https://github.com/ethereum/EIPs/issues/1411) **is an extension of the** [**ERC-20**](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) **through the combination of 4 independent ERCs**:
@@ -265,7 +261,7 @@ ATS provides an easy-to-use comprehensive framework and makes asset tokenization
 
 For those interested in technical architecture, ATS utilizes factory contracts to create new digital securities, resolver contracts to manage and execute specific functions, and proxy contracts to enable seamless upgrades. When tokenization is initiated, two smart contracts are deployed, these contracts work together with the proxy contract to create, operate, and upgrade [digital securities](/support/glossary#digital-security).
 
-- **Factory Contract:** This contract is used to create new **digital securities**, like bonds or equities. It has methods like `deployBond` and `deployEquity` to generate these tokens. Each security token is created with a **diamond proxy**, a design that allows flexible and modular contract logic.
+- **Factory Contract:** This contract is used to create new **digital securities**, like bonds or equities. It has methods like `deployBond` and `deployEquity` to generate these tokens. Each security token is created with a **diamond proxy** following the [EIP-2535 Diamond Standard](https://eips.ethereum.org/EIPS/eip-2535), a design that allows flexible and modular contract logic.
 - **Resolver Contract**: This contract links to different logic modules, each serving a specific function for the **security tokens**. When a tokenized asset needs to perform an action, it refers to the resolver contract to find the right module to execute that function.
 - **Proxy Contract**: This contract acts as a layer wrapped around each **security token**, directing operations to the main logic contract. If the rules or functions of a token need to change (e.g., due to new regulations), the proxy can be updated to point to a new logic contract via the resolver. This allows all assets to be updated without interrupting their operation.
 
@@ -275,11 +271,3 @@ This architecture allows administrators or issuers to update their digital secur
   <img src="/images/open-source-solutions/asset-tokenization-studio-ats/asset-tokenization-studio-ats-2.png" />
 </Frame>
 
-<Columns cols={2}>
-  <Card title="Editor: Krystal, Senior DX Engineer" arrow>
-    [GitHub](https://github.com/theekrystallee) |
-    [X](https://x.com/theekrystallee)
-  </Card>
-</Columns>
-
-hedera\open-source-solutions\asset-tokenization-studio-ats.mdx

--- a/solutions/tokenization/ats/web-ui.mdx
+++ b/solutions/tokenization/ats/web-ui.mdx
@@ -161,8 +161,12 @@ To initiate the creation of a new bond, choose New Bond and enter the basic deta
 Toggle the permissions you want to enable for your new bond:
 
 * **Controllable**: Enables token controller role and compliance operations.
-* **Blocklist**: Enables access control to the security using a list of blocked accounts.
-* **Approval list**: Enables access control to the security using a list of approved/allowed accounts.
+* **Blocklist**: Enables access control using a list of blocked accounts.
+* **Approval list**: Enables access control using a list of approved accounts.
+
+<Warning>
+Blocklist and Approval list are mutually exclusive — you can enable one or the other, not both, on a single token.
+</Warning>
 
 <Frame>
   <img src="/images/open-source-solutions/asset-tokenization-studio-ats/web-user-interface-ui/asset-tokenization-studio-create-bond-permissions.png" />
@@ -291,8 +295,12 @@ To initiate the creation of new equity, choose New Equity and enter the basic de
 Toggle the permissions you want to enable for your new equity:
 
 * **Controllable**: Enables token controller role and compliance operations.
-* **Blocklist**: Enables access control to the security using a list of blocked accounts.
-* **Approval list**: Enables access control to the security using a list of approved/allowed accounts.
+* **Blocklist**: Enables access control using a list of blocked accounts.
+* **Approval list**: Enables access control using a list of approved accounts.
+
+<Warning>
+Blocklist and Approval list are mutually exclusive — you can enable one or the other, not both, on a single token.
+</Warning>
 
 <Frame>
   <img src="/images/open-source-solutions/asset-tokenization-studio-ats/web-user-interface-ui/web-user-interface-ui-11.png" />
@@ -405,7 +413,7 @@ Roles you can manage include:
 * **Controller**: Authorizes the account to execute specific control actions over the tokenized asset, such as regulatory or operational updates.
 * **Pause**: Allows the account to temporarily halt all transactions for the asset, useful in emergencies or during maintenance.
 * **Control List**: Manages approval lists and blacklists, determining which accounts can or cannot participate in asset transactions.
-* **Corporate Actions**: Enables the execution of corporate actions like dividend distributions or token conversions.
+* **Corporate Actions**: Enables the execution of corporate actions like dividend distributions (equities) and coupon payments (bonds).
 * **Document**: Grants the ability to manage and update asset-related documents, such as legal or compliance files.
 * **Snapshot**: Authorizes the creation of snapshots, capturing the state of token holder balances at a specific point in time for reporting or auditing purposes.
 
@@ -528,7 +536,7 @@ The **SSI Manager** manages the list of **trusted issuers** * entities authorize
 **How to add:**
 
 1. Make sure you have assigned yourself the SSI Role under 'Roles'
-2. Go to token detail → **SST Manager** tab
+2. Go to token detail → **SSI Manager** tab
 3. Click **Add Issuer**
 4. Enter your **Hedera Account ID**: `0.0.xxx` (the account that will sign VCs)
 5. Click **Add**
@@ -561,6 +569,8 @@ Now your account is authorized to issue Verifiable Credentials that this token w
 
 ## Additional Resources
 
+* [ATS Official Documentation](https://docs.tokenization-studio.hedera.com/)
+* [ATS Source Code](https://github.com/hashgraph/asset-tokenization-studio)
 * [Hedera Developer Portal](https://portal.hedera.com/)
 * [HashScan Network Explorer](https://hashscan.io/)
 * [Frequently Asked Questions (FAQs)](/solutions/tokenization/ats/faq)


### PR DESCRIPTION
**summary**:

- fix broken smart contracts card link 
- add official ats docs link (docs.tokenization-studio.hedera.com)
- clarify erc-3643 as partial support by default
- add blocklist/approval list mutual exclusivity warning to bond and equity flows
- correct corporate actions role (remove "token conversions", add "coupon payments (bonds)")
- add fireblocks and aws kms alongside dfns in custody integrations
- clarify metamask connects directly; hashpack/blade via walletconnect 2.0
- name eip-2535 diamond standard in architecture section
- add blade wallet to supported wallets in faq
- remove stale launch badges and leftover file artifacts

**Related issue(s)**:

Fixes #680 #681 