### PR TITLE
docs: improve SEO titles and descriptions for scaffold-hbar, ATS, EVM pages

### DIFF
--- a/evm/development/accounts.mdx
+++ b/evm/development/accounts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Account Model for EVM Developers"
-description: "How Hedera accounts work in EVM context: every EVM address maps to a native account entity with an Account ID. Covers hollow accounts, long-zero accounts, completion, and token association behavior."
+description: "How Hedera accounts work in EVM contexts: EVM addresses map to native account entities, covering hollow accounts, long-zero accounts, and token association."
 ---
 
 On Hedera, every active EVM address corresponds to a registered account entity with a native **Account ID** (e.g., `0.0.1234`). Unlike Ethereum, where any address can exist implicitly without ever being registered, a Hedera account entity is only created when HBAR or tokens are first sent to an address, or when an account is explicitly created. Understanding this model is important when building dApps that interact with users holding different account types.

--- a/evm/quickstart/get-test-hbar.mdx
+++ b/evm/quickstart/get-test-hbar.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Testnet Faucet"
+description: "Get testnet HBAR using the Hedera Portal or faucet: fund an EVM wallet address instantly or create a portal account with a stable Account ID and keys."
 ---
 
 There are two ways to get testnet HBAR:

--- a/solutions/index.mdx
+++ b/solutions/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Open-Source Solutions"
-description: "Open-source studios and toolkits for tokenization, AI agents, governance, sustainability, and developer tooling on Hedera."
+title: "Open-source Hedera solutions: studios and toolkits"
+description: "Browse open-source Hedera studios and toolkits for tokenization, AI agents, DAO governance, sustainability, and developer tooling like Scaffold HBAR."
 mode: wide
 ---
 

--- a/solutions/tokenization/ats/faq.mdx
+++ b/solutions/tokenization/ats/faq.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Frequently Asked Questions (FAQs)"
+title: "Asset Tokenization Studio FAQs: features, roles, compliance"
+description: "Answers to common questions about Asset Tokenization Studio: source code access, supported assets, roles, compliance, and Hedera integration."
 ---
 
 <AccordionGroup>

--- a/solutions/tokenization/ats/index.mdx
+++ b/solutions/tokenization/ats/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Asset Tokenization Studio
+title: "Asset Tokenization Studio: tokenize RWAs on Hedera"
+description: "Open-source Hedera platform for tokenizing real-world assets—stocks, bonds, real estate—into compliant digital securities under SEC Reg D and Reg S."
 ---
 
 ## Introduction to Asset Tokenization

--- a/solutions/tokenization/ats/web-ui.mdx
+++ b/solutions/tokenization/ats/web-ui.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Web User Interface (UI)"
+title: "Asset Tokenization Studio web UI: issue and manage assets"
+description: "Use the Asset Tokenization Studio web UI to tokenize real-world assets, assign roles, run corporate actions, and enforce regulatory compliance on Hedera."
 ---
 
 

--- a/solutions/tools/scaffold-hbar/index.mdx
+++ b/solutions/tools/scaffold-hbar/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Scaffold HBAR"
+title: "Scaffold HBAR: CLI for bootstrapping Hedera dApps"
 description: "Scaffold Hedera dApps from the command line. Pick a template, frontend, and Solidity framework—then get a runnable project in one step."
 ---
 

--- a/solutions/tools/scaffold-hbar/scaffold-ui.mdx
+++ b/solutions/tools/scaffold-hbar/scaffold-ui.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Scaffold UI"
-description: "Shared React components, hooks, and an MCP server for building Hedera dApps with AI-assisted development."
+title: "Scaffold UI: React components and hooks for Hedera dApps"
+description: "Shared React components, hooks, debug UI, and an MCP server for building Hedera and EVM-compatible dApps with AI-assisted development."
 ---
 
 ## Overview


### PR DESCRIPTION
**Description**:
Updates title and description frontmatter on 8 pages to improve search discoverability. Titles are made descriptive rather than generic; descriptions are brought into the 130–160 character target range.

**Related issue(s)**:

Fixes #676 