### PR TITLE
docs: add pectra support (HIP-1341)

### DIFF
--- a/evm/development/deploying.mdx
+++ b/evm/development/deploying.mdx
@@ -3,11 +3,13 @@ title: "Deploying Smart Contracts"
 ---
 
 
-After compiling your smart contract, you can deploy it to the Hedera network. The constructor's "*init code*" includes the contract's entire bytecode. When deploying, the EVM is expected to be supplied with both the smart contract [bytecode](/support/glossary#bytecode) and the gas required to execute and deploy the contract. Post-deployment, the constructor is removed, leaving only the `runtime_bytecode` for future contract interactions.
+After compiling your smart contract, you can deploy it to the Hedera network. The deployment payload, or "*init code*", contains the constructor logic together with the contract's runtime bytecode. When deploying, the EVM is expected to be supplied with both the smart contract [bytecode](/support/glossary#bytecode) and the gas required to execute and deploy the contract. The constructor runs once during deployment and returns the `runtime_bytecode`, which is what's stored on-chain for future contract interactions.
 
 **➡** [**Hyperledger Besu EVM**](#hyperledger-besu-evm-on-hedera)
 
-**➡** [**Cancun Hard Fork**](#cancun-hard-fork)
+**➡** [**Pectra Hard Fork**](#pectra-hard-fork)
+
+**➡** [**Past Hard Forks**](#past-hard-forks)
 
 **➡** [**Solidity Variables and Opcodes**](#solidity-variables-and-opcodes)
 
@@ -19,15 +21,17 @@ The [Ethereum Virtual Machine (EVM)](/support/glossary#ethereum-virtual-machine-
 
 On Hedera, users can interact with the EVM-compatible environment in several ways. They can submit `ContractCreate`, `EthereumTransaction`, or make `eth_sendRawTransaction` RPC calls with the contract bytecode directly. These various paths allow developers to deploy and manage smart contracts efficiently.
 
-When the EVM receives the bytecode, it will be further broken down into operation codes ([opcodes](/support/glossary#opcodes)). The EVM opcodes represent the specific instructions it can perform. Each opcode is one byte and has its own gas cost associated with it. The cost per opcode for the Ethereum Cancun hard fork can be found [here](https://www.evm.codes/?fork=cancun).
+When the EVM receives the bytecode, it will be further broken down into operation codes ([opcodes](/support/glossary#opcodes)). The EVM opcodes represent the specific instructions it can perform. Each opcode is one byte and has its own gas cost associated with it. The cost per opcode for the Ethereum Pectra hard fork (Prague EVM execution layer) can be found [here](https://www.evm.codes/?fork=prague).
 
 #### Smart Contract Opcode Example
 
-```solidity
+<Accordion title="Example: compiled contract bytecode disassembled into opcodes">
+```text wrap
 PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH2 0x10 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x40 MLOAD PUSH2 0x558 CODESIZE SUB DUP1 PUSH2 0x558 DUP4 CODECOPY DUP2 DUP2 ADD PUSH1 0x40 MSTORE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x33 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 ADD SWAP1 DUP1 DUP1 MLOAD PUSH1 0x40 MLOAD SWAP4 SWAP3 SWAP2 SWAP1 DUP5 PUSH5 0x100000000 DUP3 GT ISZERO PUSH2 0x53 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP4 DUP3 ADD SWAP2 POP PUSH1 0x20 DUP3 ADD DUP6 DUP2 GT ISZERO PUSH2 0x69 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 MLOAD DUP7 PUSH1 0x1 DUP3 MUL DUP4 ADD GT PUSH5 0x100000000 DUP3 GT OR ISZERO PUSH2 0x86 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 DUP4 MSTORE PUSH1 0x20 DUP4 ADD SWAP3 POP POP POP SWAP1 DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 DUP1 DUP4 DUP4 PUSH1 0x0 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0xBA JUMPI DUP1 DUP3 ADD MLOAD DUP2 DUP5 ADD MSTORE PUSH1 0x20 DUP2 ADD SWAP1 POP PUSH2 0x9F JUMP JUMPDEST POP POP POP POP SWAP1 POP SWAP1 DUP2 ADD SWAP1 PUSH1 0x1F AND DUP1 ISZERO PUSH2 0xE7 JUMPI DUP1 DUP3 SUB DUP1 MLOAD PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB NOT AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP JUMPDEST POP PUSH1 0x40 MSTORE POP POP POP CALLER PUSH1 0x0 DUP1 PUSH2 0x100 EXP DUP2 SLOAD DUP2 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF MUL NOT AND SWAP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND MUL OR SWAP1 SSTORE POP DUP1 PUSH1 0x1 SWAP1 DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 PUSH2 0x144 SWAP3 SWAP2 SWAP1 PUSH2 0x14B JUMP JUMPDEST POP POP PUSH2 0x1E8 JUMP JUMPDEST DUP3 DUP1 SLOAD PUSH1 0x1 DUP2 PUSH1 0x1 AND ISZERO PUSH2 0x100 MUL SUB AND PUSH1 0x2 SWAP1 DIV SWAP1 PUSH1 0x0 MSTORE PUSH1 0x20 PUSH1 0x0 KECCAK256 SWAP1 PUSH1 0x1F ADD PUSH1 0x20 SWAP1 DIV DUP2 ADD SWAP3 DUP3 PUSH1 0x1F LT PUSH2 0x18C JUMPI DUP1 MLOAD PUSH1 0xFF NOT AND DUP4 DUP1 ADD OR DUP6 SSTORE PUSH2 0x1BA JUMP JUMPDEST DUP3 DUP1 ADD PUSH1 0x1 ADD DUP6 SSTORE DUP3 ISZERO PUSH2 0x1BA JUMPI SWAP2 DUP3 ADD JUMPDEST DUP3 DUP2 GT ISZERO PUSH2 0x1B9 JUMPI DUP3 MLOAD DUP3 SSTORE SWAP2 PUSH1 0x20 ADD SWAP2 SWAP1 PUSH1 0x1 ADD SWAP1 PUSH2 0x19E JUMP JUMPDEST JUMPDEST POP SWAP1 POP PUSH2 0x1C7 SWAP2 SWAP1 PUSH2 0x1CB JUMP JUMPDEST POP SWAP1 JUMP JUMPDEST JUMPDEST DUP1 DUP3 GT ISZERO PUSH2 0x1E4 JUMPI PUSH1 0x0 DUP2 PUSH1 0x0 SWAP1 SSTORE POP PUSH1 0x1 ADD PUSH2 0x1CC JUMP JUMPDEST POP SWAP1 JUMP JUMPDEST PUSH2 0x361 DUP1 PUSH2 0x1F7 PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH2 0x10 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH2 0x36 JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x2E982602 EQ PUSH2 0x3B JUMPI DUP1 PUSH4 0x32AF2EDB EQ PUSH2 0xF6 JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH2 0xF4 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x51 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 ADD SWAP1 DUP1 DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP1 PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x6E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x80 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x1 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xA2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP1 DUP1 DUP1 PUSH1 0x1F ADD PUSH1 0x20 DUP1 SWAP2 DIV MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 DUP2 DUP5 ADD MSTORE PUSH1 0x1F NOT PUSH1 0x1F DUP3 ADD AND SWAP1 POP DUP1 DUP4 ADD SWAP3 POP POP POP POP POP POP POP SWAP2 SWAP3 SWAP2 SWAP3 SWAP1 POP POP POP PUSH2 0x179 JUMP JUMPDEST STOP JUMPDEST PUSH2 0xFE PUSH2 0x1EC JUMP JUMPDEST PUSH1 0x40 MLOAD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE DUP4 DUP2 DUP2 MLOAD DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 DUP1 DUP4 DUP4 PUSH1 0x0 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x13E JUMPI DUP1 DUP3 ADD MLOAD DUP2 DUP5 ADD MSTORE PUSH1 0x20 DUP2 ADD SWAP1 POP PUSH2 0x123 JUMP JUMPDEST POP POP POP POP SWAP1 POP SWAP1 DUP2 ADD SWAP1 PUSH1 0x1F AND DUP1 ISZERO PUSH2 0x16B JUMPI DUP1 DUP3 SUB DUP1 MLOAD PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB NOT AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP JUMPDEST POP SWAP3 POP POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 RETURN JUMPDEST PUSH1 0x0 DUP1 SLOAD SWAP1 PUSH2 0x100 EXP SWAP1 DIV PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x1D1 JUMPI PUSH2 0x1E9 JUMP JUMPDEST DUP1 PUSH1 0x1 SWAP1 DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 PUSH2 0x1E7 SWAP3 SWAP2 SWAP1 PUSH2 0x28E JUMP JUMPDEST POP JUMPDEST POP JUMP JUMPDEST PUSH1 0x60 PUSH1 0x1 DUP1 SLOAD PUSH1 0x1 DUP2 PUSH1 0x1 AND ISZERO PUSH2 0x100 MUL SUB AND PUSH1 0x2 SWAP1 DIV DUP1 PUSH1 0x1F ADD PUSH1 0x20 DUP1 SWAP2 DIV MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP1 SLOAD PUSH1 0x1 DUP2 PUSH1 0x1 AND ISZERO PUSH2 0x100 MUL SUB AND PUSH1 0x2 SWAP1 DIV DUP1 ISZERO PUSH2 0x284 JUMPI DUP1 PUSH1 0x1F LT PUSH2 0x259 JUMPI PUSH2 0x100 DUP1 DUP4 SLOAD DIV MUL DUP4 MSTORE SWAP2 PUSH1 0x20 ADD SWAP2 PUSH2 0x284 JUMP JUMPDEST DUP3 ADD SWAP2 SWAP1 PUSH1 0x0 MSTORE PUSH1 0x20 PUSH1 0x0 KECCAK256 SWAP1 JUMPDEST DUP2 SLOAD DUP2 MSTORE SWAP1 PUSH1 0x1 ADD SWAP1 PUSH1 0x20 ADD DUP1 DUP4 GT PUSH2 0x267 JUMPI DUP3 SWAP1 SUB PUSH1 0x1F AND DUP3 ADD SWAP2 JUMPDEST POP POP POP POP POP SWAP1 POP SWAP1 JUMP JUMPDEST DUP3 DUP1 SLOAD PUSH1 0x1 DUP2 PUSH1 0x1 AND ISZERO PUSH2 0x100 MUL SUB AND PUSH1 0x2 SWAP1 DIV SWAP1 PUSH1 0x0 MSTORE PUSH1 0x20 PUSH1 0x0 KECCAK256 SWAP1 PUSH1 0x1F ADD PUSH1 0x20 SWAP1 DIV DUP2 ADD SWAP3 DUP3 PUSH1 0x1F LT PUSH2 0x2CF JUMPI DUP1 MLOAD PUSH1 0xFF NOT AND DUP4 DUP1 ADD OR DUP6 SSTORE PUSH2 0x2FD JUMP JUMPDEST DUP3 DUP1 ADD PUSH1 0x1 ADD DUP6 SSTORE DUP3 ISZERO PUSH2 0x2FD JUMPI SWAP2 DUP3 ADD JUMPDEST DUP3 DUP2 GT ISZERO PUSH2 0x2FC JUMPI DUP3 MLOAD DUP3 SSTORE SWAP2 PUSH1 0x20 ADD SWAP2 SWAP1 PUSH1 0x1 ADD SWAP1 PUSH2 0x2E1 JUMP JUMPDEST JUMPDEST POP SWAP1 POP PUSH2 0x30A SWAP2 SWAP1 PUSH2 0x30E JUMP JUMPDEST POP SWAP1 JUMP JUMPDEST JUMPDEST DUP1 DUP3 GT ISZERO PUSH2 0x327 JUMPI PUSH1 0x0 DUP2 PUSH1 0x0 SWAP1 SSTORE POP PUSH1 0x1 ADD PUSH2 0x30F JUMP JUMPDEST POP SWAP1 JUMP INVALID LOG2 PUSH5 0x6970667358 0x22 SLT KECCAK256 AND DIFFICULTY CHAINID 0x5F 0x5F PUSH20 0xDFD73A518B57770F5ADB27F025842235980D7A0F 0x4E ISZERO 0xB1 0xAC 0xB1 DUP15 PUSH5 0x736F6C6343 STOP SMOD STOP STOP CALLER
 ```
+</Accordion>
 
-Reference: https://ethervm.io/
+Reference: [ethervm.io](https://ethervm.io/)
 
 ***
 
@@ -59,7 +63,7 @@ If you need to set any of the above properties for your contract, you will have 
 
 ### Deploying Large Contracts
 
-Hedera supports **jumbo Ethereum transactions (**[**HIP-1086**](https://hips.hedera.com/hip/hip-1086)**)** for large bytecode payloads. You can include up to **24KB for contract creation** and **128KB for contract calls** directly in `ethereumData`, without using the File Service (`callDataFileId`).
+Hedera supports **jumbo Ethereum transactions (**[**HIP-1086**](https://hips.hedera.com/hip/hip-1086)**)** for large bytecode payloads, letting you include `callData` directly in `ethereumData` without using the File Service (`callDataFileId`). The exact ceilings are **network-configurable parameters**, not fixed protocol constants; current values are on the order of **~24KB for contract creation** (the [EIP-170](https://eips.ethereum.org/EIPS/eip-170) code-size limit) and **~128KB for contract calls**. Check the active network configuration for the precise limits.
 
 However, jumbo transactions:
 
@@ -70,9 +74,8 @@ However, jumbo transactions:
 
 When deploying contracts, gas must cover both intrinsic gas and the cost of executing deployment code. Intrinsic gas includes a base fee (21,000) plus a per-byte cost for `callData`:
 
-* Intrinsic gas includes a base fee (21,000) plus a per-byte cost for `callData`:
-  * 4 gas per zero byte
-  * 16 gas per non-zero byte
+* 4 gas per zero byte
+* 16 gas per non-zero byte
 
 #### Example
 
@@ -82,43 +85,105 @@ If your contract bytecode is 10KB, with 20% (2KB) as zero bytes and 80% (8KB) as
 * **gas for non-zero bytes**: 16 × 8,192 = 131,072
 * **total intrinsic gas** = 21,000 + 8,192 + 131,072 = 160,264
 
+Under Pectra, the transaction also has to satisfy the [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) calldata floor: `21000 + 10 × (zero + 4 × non_zero)`. For this example that floor is `21,000 + 10 × (2,048 + 4 × 8,192) = 369,160` gas, well above the 160,264 intrinsic figure. The deployment pays whichever is greater: the intrinsic **plus execution** total, or the floor. In practice deployment execution includes the code-deposit charge (200 gas per byte of runtime bytecode, roughly 2M gas for a 10KB contract), which pushes the standard total far past the floor, so the floor mainly matters for calldata-heavy transactions with little execution work.
+
 Ensure you adjust `gasLimit` (RLP) and `maxGasAllowance` (wrapper) to cover this total gas.
 
-📣 Learn more on the [Gas and Fees page,](/evm/development/gas-fees) [EthereumTransaction SDK page](/native/smart-contracts/ethereum-transaction), and the [Understanding Hedera's EVM Differences and Compatibility page](/evm/differences).
-
+<Info>
+  📣 Learn more on the [Gas and Fees page,](/evm/development/gas-fees) [`EthereumTransaction` SDK page](/native/smart-contracts/ethereum-transaction), and the [Understanding Hedera's EVM Differences and Compatibility page](/evm/differences).
+</Info>
 ***
 
 ## Hyperledger Besu EVM on Hedera
 
 The Hedera network nodes utilize the [HyperLedger Besu EVM ](/support/glossary#hyperledger-besu-evm)Client written in Java as an execution layer for Ethereum-type transactions. The codebase is up to date with the current Ethereum Mainnet hard forks. The Besu EVM client library is used without hooks for Ethereum's consensus, networking, and storage features. Instead, Hedera hooks into its own Hashgraph consensus, Gossip communication, and [Virtual Merkle Trees](/support/glossary#virtual-merkle-tree) components for greater fault tolerance, finality, and scalability.
 
-As of the Hedera Mainnet release [`0.50.0`](/networks/release-notes/services#v0.50), the Besu EVM client is configured to support the Cancun hard fork of the Ethereum Mainnet, with some modifications.
+The Besu EVM client is configured to support the **Pectra hard fork** of the Ethereum Mainnet (activated May 7, 2025), with some modifications. Pectra was introduced on Hedera under [HIP-1341](https://hips.hedera.com/hip/hip-1341) (Support for Ethereum Pectra Release).
 
-### **Cancun Hard Fork**
+<Info>
+**EIP-7702 is deactivated.** Hedera runs the Prague EVM, but EIP-7702 (set EOA account code), and therefore EOA Code Delegation, is currently disabled. Type 4 (set-code) transactions are not accepted and no account delegation takes execution effect. The other applicable Pectra EIPs (EIP-2537 and EIP-7623, below) are active.
+</Info>
 
-The smart contract platform has been upgraded to support the visible EVM changes introduced in the [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) hard fork. This includes adding new opcodes for transient storage and memory copy, semantic updates for opcodes introduced certain operations introduced in the [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md), [London](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md), [Istanbul](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md), and [Berlin](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md) hard forks, except those with changes in block production, data serialization, and the double fee market.
+### **Pectra Hard Fork**
 
-As of the Consensus Node [0.22](/networks/release-notes/services#v0.22) release, gas and input data costs are charged. The amount of intrinsic gas consumed is a constant charge that occurs before any code executes. The intrinsic gas cost is 21,000. The associated cost of input data is 16 gas for each byte of data that is not zero and 4 gas for each byte of data that is zero. The amount of intrinsic gas consumed is charged in relation to the data supplied when making a contract call to the function parameters of external contracts. The gas schedule and the fees table can be found in the gas section of this documentation page.
+The smart contract platform has been upgraded to support the visible EVM changes introduced in the [Pectra](https://eips.ethereum.org/EIPS/eip-7600) hard fork (Prague execution layer + Electra consensus layer). The applicable EIPs adopted on Hedera are:
+
+| EIP                                                  | Title                                | Summary                                                                                                       |
+| ---------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537)  | BLS12-381 curve precompiles          | Adds precompiles at addresses `0x0b`–`0x11` for efficient BLS signature/pairing operations.                  |
+| [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)  | Increase calldata cost (floor)       | Introduces a calldata gas floor: `21000 + 10 × (zero_bytes + 4 × non_zero_bytes)`.                            |
+
+[EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) (Set EOA account code) is part of Pectra but is **currently deactivated on Hedera**: Type 4 transactions are not accepted and no EOA code delegation takes effect.
+
+The following Pectra EIPs are **not applicable** to Hedera and are not adopted: EIP-7691, EIP-7840 (blob-related, Hedera does not support blobs), EIP-6110, EIP-7002, EIP-7251, EIP-7685 (Ethereum validator features, no Hedera equivalent), EIP-2935, EIP-7549 (Ethereum 2.0 features), EIP-7642 (informational). Per [HIP-1341](https://hips.hedera.com/hip/hip-1341).
+
+As of the Consensus Node [0.22](/learn/release-notes/services#v0.22) release ([HIP-185](https://hips.hedera.com/hip/hip-185)), gas and input data costs are charged. The amount of intrinsic gas consumed is a constant charge that occurs before any code executes. _The intrinsic gas cost is `21,000`_. The associated cost of input data is 16 gas for each byte of data that is not zero and 4 gas for each byte of data that is zero. Under Pectra (EIP-7623), an additional floor of `21000 + 10 × (zero + 4 × non_zero)` applies to calldata-heavy transactions. The amount of intrinsic gas consumed is charged in relation to the data supplied when making a contract call to the function parameters of external contracts. The gas schedule and the fees table can be found in the gas section of this documentation page.
+
+#### Supported Ethereum Transaction Types
+
+`EthereumTransaction` accepts RLP-encoded payloads for all of the following types:
+
+| Type | Spec                                                  | Description                                                                                                   |
+| :--: | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `0`  | Legacy ([EIP-155](https://eips.ethereum.org/EIPS/eip-155))    | Pre-Berlin legacy transactions.                                                                       |
+| `1`  | [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)   | Optional `access_list` to pre-warm storage slots and addresses.                                              |
+| `2`  | [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)   | `max_fee_per_gas` + `max_priority_fee_per_gas` (priority fee is ignored on Hedera; fees are fixed by the network). |
+
+Type 3 (blob transactions per EIP-4844) is **not supported** on Hedera (see [HIP-866](https://hips.hedera.com/hip/hip-866)). Type 4 ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)) is also **not accepted**: EOA Code Delegation is currently deactivated.
 
 <Frame>
   <img src="/images/core-concepts/smart-contracts/deploying-smart-contracts/deploying-smart-contracts-1.jpg" />
 </Frame>
 
-#### Proto-Danksharding
+#### Blobs supported on Hedera?
 
-As an interim solution to full sharding, introduced in the Cancun hard fork, the proto-danksharding offers some of the advantages of sharding with reduced complexity and infrastructure changes that are part of a sharding implementation. This, in turn, opens the gates for adding "blobs" of data to append to blocks to increase data availability further and allow more processing efficiency.
+Hedera does not provide blobs under [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) (Cancun), nor under the Pectra blob-throughput EIPs ([EIP-7691](https://eips.ethereum.org/EIPS/eip-7691), [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840)). [HIP-866](https://hips.hedera.com/hip/hip-866) defines how Hedera behaves without blob support. To preserve compatibility and future design space, Hedera acts as if blobs are not being added. This allows existing contracts that depend on blob behavior to function without blobs. Blobs are prevented from entering the system by prohibiting "Type 3" transactions, which enable blobs. This keeps blobs out of the EVM's concern without affecting other desirable interactions on Hedera. With jumbo `EthereumTransaction` support ([HIP-1086](https://hips.hedera.com/hip/hip-1086)) on Hedera, large `callData` payloads are the preferred path for rollup-style data.
 
-Blobs are big data objects within blocks. These can be utilized to store rollups (Layer 2 solutions) and different kinds of apps requiring big data objects to be stored in an efficient way. This is data off-chain for the validators and requires minimal processing on their part. It reduces the computational load on the network and hence reduces the transaction gas fee.
+### **Past Hard Forks**
 
-#### ❌ Blobs supported on Hedera?
+Hedera tracks Ethereum mainnet hard forks and adopts the EIPs that apply to the Smart Contract Service. The table below summarizes recent forks and the practical differences between them on Hedera.
 
-Hedera does not provide blobs under [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844). [HIP-866](https://hips.hedera.com/hip/hip-866) defines how Hedera behaves without blob support. To preserve compatibility and future design space, Hedera will act as if blobs are not being added. This allows existing contracts dependent on blob behavior to function without blobs. Blobs will be prevented from entering the system by prohibiting "Type 3" transactions, which enable blobs. This will keep blobs out of the EVM's concern without affecting other desirable interactions on Hedera.
+| Fork (Ethereum activation) | First adopted on Hedera                                                            | Headline changes on Hedera                                                                                                                                                                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pectra** (May 7, 2025)   | [HIP-1341](https://hips.hedera.com/hip/hip-1341) | • [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537): BLS12-381 precompiles (`0x0b`–`0x11`). <br/>• [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623): calldata gas floor. <br/>• [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) (Type 4 / EOA code delegation): **deactivated on Hedera**. |
+| **Cancun** (Mar 13, 2024)  | Mainnet release [`v0.50`](/learn/release-notes/services#v0.50)          | • New opcodes `TLOAD`/`TSTORE` (transient storage), `MCOPY`, `BLOBHASH`, `BLOBBASEFEE`. <br/>• `SELFDESTRUCT` semantics updated per [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780). <br/>• Blob support (EIP-4844) **not** adopted; Type 3 transactions are rejected ([HIP-866](https://hips.hedera.com/hip/hip-866)).                              |
+| **Shanghai** (Apr 12, 2023)| Mainnet release [`v0.38`](/learn/release-notes/services#v0.38)                      | • `PUSH0` opcode. <br/>• Updated `INITCODE` cost for contract creation.                                                                                                                                                                                                                                     |
+
+#### What changed from Cancun to Pectra?
+
+If you previously targeted Cancun, the practical differences on Hedera are:
+
+1. **Calldata floor (EIP-7623).** Calldata-heavy transactions must now pay at least `21000 + 10 × (zero_bytes + 4 × non_zero_bytes)`. Standard contract calls (where execution gas dominates) are unaffected.
+2. **BLS12-381 precompiles (EIP-2537).** Seven new precompiles at addresses `0x0b`–`0x11` for G1/G2 add, multi-scalar multiplication, pairing check, and field-to-curve mapping. These make BLS aggregation, threshold signatures, and zk-friendly cryptography native (no Solidity gymnastics).
+3. **EOA Code Delegation (EIP-7702) is deactivated.** Type 4 transactions are not accepted and EOAs cannot delegate execution to a contract. `eth_getCode(eoa)` continues to return empty for externally owned accounts.
+
+> Blobs (EIP-4844 / EIP-7691 / EIP-7840) remain unsupported on Hedera. Type 3 transactions are rejected.
 
 ### Solidity Variables and Opcodes
 
-The table below defines the mapping of Solidity variables and operation codes to Hedera. The full list of supported Opcodes for the Cancun hard fork can be found [here](https://www.evm.codes/).
+The table below defines the mapping of Solidity variables and operation codes to Hedera. The full list of supported Opcodes for the Pectra hard fork (Prague EVM execution layer) can be found [here](https://www.evm.codes/?fork=prague).
 
-<table><thead><tr><th align="center">Solidity</th><th align="center">Opcode</th><th>Hedera</th></tr></thead><tbody><tr><td align="center"><code>address</code></td><td align="center"></td><td>The address is a mapping of shard.realm.number (0.0.10) into a 20 byte Solidity address. The address can be a Hedera account ID or contract ID in Solidity format.</td></tr><tr><td align="center"><code>block.basefee</code></td><td align="center"><code>BASEFEE</code></td><td>The <code>BASEFEE</code> opcode will return zero. Hedera does not use the Fee Market mechanism this is designed to support.</td></tr><tr><td align="center"><code>block.chainId</code></td><td align="center"><code>CHAINID</code></td><td>The <code>CHAINID</code> opcode will return 295(hex <code>0x0127</code>) for mainnet, 296( hex <code>0x0128</code>) for testnet, 297( hex <code>0x0129</code>) for previewnet, and 298 (<code>0x12A</code>) for development networks.</td></tr><tr><td align="center"><code>block.coinbase</code></td><td align="center"><code>COINBASE</code></td><td>The <code>COINBASE</code> operation will return the funding account (Hedera transaction fee collecting account <code>0.0.98</code>).</td></tr><tr><td align="center"><code>block.number</code></td><td align="center"></td><td>The index of the record file (not recommended, use <code>block.timestamp</code>).</td></tr><tr><td align="center"><code>block.timestamp</code></td><td align="center"></td><td>The transaction consensus timestamp.</td></tr><tr><td align="center"><code>block.difficulty</code></td><td align="center"></td><td>Always zero.</td></tr><tr><td align="center"><code>block.gaslimit</code></td><td align="center"><code>GASLIMIT</code></td><td>The <code>GASLIMIT</code> operation will return the <code>gasLimit</code> of the transaction. The transaction <code>gasLimit</code> will be the lowest of the gas limit requested in the transaction or a global upper gas limit configured for all smart contracts.</td></tr><tr><td align="center"><code>msg.sender</code></td><td align="center"></td><td>The address of the Hedera contract ID or account ID in Solidity format that called this contract. For the root level or for delegate chains that go to the root, it is the account ID paying for the transaction.</td></tr><tr><td align="center"><code>msg.value</code></td><td align="center"></td><td>The value associated to the transaction associated in tinybar.</td></tr><tr><td align="center"><code>tx.origin</code></td><td align="center"></td><td>The account ID paying for the transaction, regardless of depth.</td></tr><tr><td align="center"><code>tx.gasprice</code></td><td align="center"></td><td>Fixed (varies with the global fee schedule and exchange rate).</td></tr><tr><td align="center"><p><code>selfdestruct</code></p><p><code>(address payable recipient)</code></p></td><td align="center"><code>SELFDESTRUCT</code></td><td>Address will not be reusable due to Hedera’s account numbering policies. On <code>SELFDESTRUCT</code> the contracts HBAR and HTS tokens are transferred to the recipients. If the recipient does not exist or does not have an allowance for any of the HTS tokens, this opcode will fail.</td></tr><tr><td align="center"><code>&#x3C;address>.code</code></td><td align="center"></td><td>Precompile contract addresses will report no code, including HTS System contract.</td></tr><tr><td align="center"><code>&#x3C;address>.codehash</code></td><td align="center"></td><td>Precompile contract addresses will report the empty code hash.</td></tr><tr><td align="center"></td><td align="center"><code>PRNGSEED</code></td><td>This opcode returns a random number based on the n-3 record running hash.</td></tr><tr><td align="center"><code>delegateCall</code></td><td align="center"></td><td>Contracts may no longer use <code>delegateCall()</code> to invoke system contracts. Contracts should instead use the <code>call()</code> method.</td></tr><tr><td align="center"><code>blobVersionedHashesAtIndex</code></td><td align="center"><code>BLOBHASH</code></td><td>The <code>BLOBHASH</code> operation will return all zeros at all times.</td></tr><tr><td align="center"><code>blobBaseFee</code></td><td align="center"><code>BLOBBASEFEE</code></td><td><p>The <code>BLOBBASEFEE</code> operation will return</p><p><code>1</code> at all times.</p></td></tr></tbody></table>
+| Solidity | Opcode | Hedera |
+| :---: | :---: | --- |
+| `address` |  | The address is a mapping of shard.realm.number (0.0.10) into a 20 byte Solidity address. The address can be a Hedera account ID or contract ID in Solidity format. |
+| `block.basefee` | `BASEFEE` | The `BASEFEE` opcode will return zero. Hedera does not use the Fee Market mechanism this is designed to support. |
+| `block.chainid` | `CHAINID` | The `CHAINID` opcode will return 295(hex `0x0127`) for mainnet, 296( hex `0x0128`) for testnet, 297( hex `0x0129`) for previewnet, and 298 (`0x12A`) for development networks. |
+| `block.coinbase` | `COINBASE` | The `COINBASE` operation will return the funding account (Hedera transaction fee collecting account `0.0.98`). |
+| `block.number` |  | The index of the record file (not recommended, use `block.timestamp`). |
+| `block.timestamp` |  | The transaction consensus timestamp. |
+| `block.difficulty` |  | Always zero. |
+| `block.gaslimit` | `GASLIMIT` | The `GASLIMIT` operation will return the `gasLimit` of the transaction. The transaction `gasLimit` will be the lowest of the gas limit requested in the transaction or a global upper gas limit configured for all smart contracts. |
+| `msg.sender` |  | The address of the Hedera contract ID or account ID in Solidity format that called this contract. For the root level or for delegate chains that go to the root, it is the account ID paying for the transaction. |
+| `msg.value` |  | The value associated to the transaction associated in tinybar. |
+| `tx.origin` |  | The account ID paying for the transaction, regardless of depth. |
+| `tx.gasprice` |  | Fixed (varies with the global fee schedule and exchange rate). |
+| `selfdestruct`<br/>`(address payable recipient)` | `SELFDESTRUCT` | Address will not be reusable due to Hedera’s account numbering policies. On `SELFDESTRUCT` the contracts HBAR and HTS tokens are transferred to the recipients. If the recipient does not exist or does not have an allowance for any of the HTS tokens, this opcode will fail. |
+| `<address>.code` |  | Precompile and system-contract addresses (including the HTS system contract at `0x167`) report no code. Externally owned accounts report empty code (EOA Code Delegation is currently deactivated). |
+| `<address>.codehash` |  | Precompile contract addresses will report the empty code hash. |
+|  | PRNG system contract (`0x169`) | There is no PRNG opcode. Per [HIP-351](https://hips.hedera.com/hip/hip-351), contracts call `getPseudorandomSeed()` on the PRNG system contract at `0x169`, which returns a 256-bit seed derived from the n-3 record running hash. |
+| `delegateCall` |  | Contracts may no longer use `delegateCall()` to invoke system contracts. Contracts should instead use the `call()` method. |
+| `blobVersionedHashesAtIndex` | `BLOBHASH` | The `BLOBHASH` operation will return all zeros at all times. |
+| `blobBaseFee` | `BLOBBASEFEE` | The `BLOBBASEFEE` operation will return<br/>`1` at all times. |
 
 Reference: [HIP-866](https://hips.hedera.com/hip/hip-866), [HIP-868](https://hips.hedera.com/hip/hip-868)
 
@@ -150,30 +215,30 @@ Understanding these differences is crucial for anyone developing smart contracts
 Yes, you can use Solidity functions directly with the Hedera EVM. However, refer to the [Solidity Variables and Opcodes](#solidity-variables-and-opcodes) table to understand any modifications to opcode descriptions that better reflect their behavior on the Hedera network.
 </Accordion>
 
-<Accordion title="Can i deploy large contracts with big bytecode?">
-Yes, hedera supports jumbo ethereum transactions (HIP-1086), allowing up to **24kb for contract creation** and **128kb for contract calls**. this eliminates the need for uploading bytecode to the file service in most cases. [Learn more](/evm/differences#jumbo-ethereum-transactions).
-</Accordion>
-
-<Accordion title="Do jumbo transactions work with batch transactions?">
-No, jumbo ethereum transactions cannot be included in a `TransactionList` (batch). each jumbo transaction must be submitted individually.
+<Accordion title="Can I deploy large contracts with big bytecode?">
+Yes. Hedera supports jumbo Ethereum transactions ([HIP-1086](https://hips.hedera.com/hip/hip-1086)), which carry `callData` directly in `ethereumData` and remove the need to upload bytecode to the File Service in most cases. Note that jumbo transactions cannot be included in a `TransactionList` (batch); each one must be submitted individually. See [Deploying Large Contracts](#deploying-large-contracts) for the current size ceilings and throttling details.
 </Accordion>
 
 <Accordion title="How does gas work when deploying a contract?">
 Gas covers intrinsic costs (base + per-byte of `callData`) and execution costs (opcodes run by the EVM). Ensure your `gasLimit` and `maxGasAllowance` cover the total. See the [gas and fees page](/evm/development/gas-fees) for details.
 </Accordion>
 
-<Accordion title="How does hedera handle <code>fallback()</code> and <code>receive()</code> functions?">
+<Accordion title="How does Hedera handle <code>fallback()</code> and <code>receive()</code> functions?">
 Hedera does not trigger `fallback()` or `receive()` functions on HBAR transfers. Balances may change through native operations, so use explicit functions to handle HBAR. [Learn more](#limitation-on-fallback-receive-functions-in-hedera-smart-contracts).
 </Accordion>
 
-<Accordion title="Can i deploy contracts using only hardhat?">
+<Accordion title="Can I deploy contracts using only Hardhat?">
 Yes, but Hardhat cannot set Hedera-native properties like admin key or token associations. For these, use the [Hedera SDK](/native/fundamentals).
 </Accordion>
 
 <Accordion title="What should I do if my contract relies on blob-related opcodes?">
-If your contract relies on blob-related opcodes introduced in the Cancun hard fork, you can still deploy it on Hedera. The blob-related opcodes **will** **not** fail. They'll return default values as [specified by the EVM](https://www.evm.codes/?fork=cancun).
+If your contract relies on blob-related opcodes introduced in the Cancun hard fork (`BLOBHASH`, `BLOBBASEFEE`), you can still deploy it on Hedera. The blob-related opcodes **will not** fail; they return default values (`0` and `1` respectively) as [specified by the EVM](https://www.evm.codes/?fork=prague). Blob transactions themselves (Type 3) remain unsupported.
 </Accordion>
 
 <Accordion title="Are there any special considerations for using updated EVM opcodes on Hedera?">
-Yes, while the Hedera EVM supports the updated opcodes from the Cancun hard fork, you should know the intrinsic gas costs and input data charges specific to Hedera. Refer to the [gas schedule and fees](/evm/development/gas-fees) table for more information.
+Yes, while the Hedera EVM supports the updated opcodes from the Pectra hard fork (including Cancun-era `TLOAD`/`TSTORE`/`MCOPY` and Pectra-era BLS12-381 precompiles), you should know the intrinsic gas costs and input data charges specific to Hedera, including the EIP-7623 calldata floor. Refer to the [gas schedule and fees](/evm/development/gas-fees) table for more information.
+</Accordion>
+
+<Accordion title="Can I use EIP-7702 (Type 4) transactions on Hedera?">
+No. EIP-7702 (set EOA account code) is currently deactivated on Hedera. Type 4 `EthereumTransaction` payloads are not accepted, and EOA code delegation has no effect. The other Pectra EIPs (EIP-2537 BLS precompiles and the EIP-7623 calldata floor) are active.
 </Accordion>

--- a/evm/development/gas-fees.mdx
+++ b/evm/development/gas-fees.mdx
@@ -37,7 +37,7 @@ Gas fees for EVM transactions consist of:
     **High-volume contract creation.** `ContractCreateTransaction` supports the
     `high_volume` flag ([HIP-1313](https://hips.hedera.com/hip/hip-1313)), which routes
     the transaction through dedicated high-volume throttle capacity with variable-rate
-    pricing. This applies to **HAPI-based contract creation only** — contract deployments
+    pricing. This applies to **HAPI-based contract creation only**; contract deployments
     via EVM `CREATE` / `CREATE2` opcodes are not included. See the
     [High-Volume Entity Creation](/learn/core-concepts/high-volume-entity-creation) guide
     for details.
@@ -45,7 +45,7 @@ Gas fees for EVM transactions consist of:
 
 ### Intrinsic Gas
 
-A transaction submitted to the smart contract service must be sent with enough gas to cover **intrinsic gas**. With the **Cancun fork** of the EVM update, intrinsic gas is calculated as:
+A transaction submitted to the smart contract service must be sent with enough gas to cover **intrinsic gas**. Under the **Pectra hard fork** (Prague EVM execution layer), intrinsic gas is calculated as:
 
 ```bash
 21000 + 4 × (number of zero bytes) + 16 × (number of non-zero bytes) = intrinsic gas
@@ -56,6 +56,16 @@ A transaction submitted to the smart contract service must be sent with enough g
 - **16 × (non-zero bytes)**: The cost for each non-zero byte in the transaction payload
 
 If insufficient gas is submitted, the transaction will **fail during precheck** and no record will be created.
+
+<Note>
+**Pectra calldata floor ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)).** Under Pectra, transactions must additionally satisfy a calldata floor:
+
+```bash
+floor = 21000 + 10 × (zero bytes + 4 × non-zero bytes)
+```
+
+The transaction pays `MAX(standard intrinsic + execution gas, floor)`. The floor primarily affects calldata-heavy transactions with low execution cost; most contract calls are unaffected. See [HIP-1341](https://hips.hedera.com/hip/hip-1341) for Pectra adoption details on Hedera.
+</Note>
 
 <Note>
 This applies to both standard transactions and **jumbo EthereumTransactions** introduced by **[HIP-1086](https://hips.hedera.com/hip/hip-1086)**, which allow larger `callData` payloads.
@@ -80,7 +90,7 @@ If `SLOAD` accesses a storage slot twice within the same transaction, the total 
 - **Second Access (Warm)** = `100 + 100 = 200 gas`
 - **Final Gas Cost Total** = `2,400 gas`
 
-📣 *Explore [opcodes in Cancun fork](https://www.evm.codes/).*
+📣 *Explore [opcodes in Pectra (Prague) fork](https://www.evm.codes/?fork=prague).*
 
 
 ### Hedera System Contract Gas
@@ -152,9 +162,9 @@ Ensure both `gasLimit` (RLP) and `maxGasAllowance` (wrapper) are set high enough
 
 The **gas limit** is the maximum amount of gas you are willing to pay for an operation.
 
-The current opcode gas fees are reflective as of the **[0.22 Hedera Service release](/networks/release-notes/services#v0.22)**.
+The current opcode gas fees are reflective as of the **[0.22 Hedera Service release](/learn/release-notes/services#v0.22)**.
 
-| Operation                                                                | Cancun Cost (Gas)                           | Current Hedera (Gas)                        |
+| Operation                                                                | Pectra Cost (Gas)                           | Current Hedera (Gas)                        |
 | ------------------------------------------------------------------------ | ------------------------------------------- | ------------------------------------------- |
 | Code deposit                                                             | 200 \* bytes                                | 200 \* bytes                                |
 | <p><code>BALANCE</code><br/>(cold account)</p>                           | 2600                                        | 2600                                        |
@@ -187,7 +197,121 @@ The terms **'warm'** and **'cold'** in the above table correspond with whether t
 
 **'CALL et al.'** includes with limitation: `CALL`, `CALLCODE`, `DELEGATECALL`, and `STATICCALL`
 
-Reference: [HIP-206](https://hips.hedera.com/hip/hip-206), [HIP-865](https://hips.hedera.com/hip/hip-865)
+**BLS12-381 precompiles ([EIP-2537](https://eips.ethereum.org/EIPS/eip-2537))** are available under Pectra at the following addresses, callable via `call` / `staticcall`:
+
+| Function              | Address | Input size (bytes) | Purpose                                                                  |
+| --------------------- | ------- | ------------------ | ------------------------------------------------------------------------ |
+| `BLS12_G1ADD`         | `0x0b`  | 256                | Add two G1 points.                                                       |
+| `BLS12_G1MSM`         | `0x0c`  | 160 × k slices     | Multi-scalar multiplication on G1 (sum of `scalar[i] × point[i]`).       |
+| `BLS12_G2ADD`         | `0x0d`  | 512                | Add two G2 points.                                                       |
+| `BLS12_G2MSM`         | `0x0e`  | 288 × k slices     | Multi-scalar multiplication on G2.                                       |
+| `BLS12_PAIRING_CHECK` | `0x0f`  | 384 × k slices     | Verify `Π e(G1_i, G2_i) == 1`, the core check for BLS signature verification. |
+| `BLS12_MAP_FP_TO_G1`  | `0x10`  | 64                 | Map a field element (`Fp`) onto the G1 curve.                            |
+| `BLS12_MAP_FP2_TO_G2` | `0x11`  | 128                | Map a field element (`Fp2`) onto the G2 curve (used in hash-to-curve).   |
+
+**Input encoding** (per EIP-2537):
+
+- `Fp` element: 64 bytes, a 48-byte field element left-padded to 64 bytes (16 bytes of leading zeros).
+- `G1` point: 128 bytes, two `Fp` elements (`x`, `y`).
+- `G2` point: 256 bytes, two `Fp2` elements, each `Fp2 = (c0, c1)` written as two `Fp` values.
+- Scalar (for MSM): 32 bytes, big-endian, full 256-bit width.
+
+Each MSM input is `point ‖ scalar`, repeated `k` times. The pairing check input is `(G1_i ‖ G2_i)` tuples of 384 bytes each, repeated `k` times.
+
+### Example: BLS signature verification
+
+The most common use case is verifying a BLS signature against a public key and message hash. The pairing check verifies `e(signature, G2_generator) == e(H(m), public_key)`, which the precompile expresses as `Π e(G1, G2) == 1` by including the second pair with a negated G1 generator.
+
+```solidity Solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title BLSVerifier
+/// @notice Verifies a single BLS signature using EIP-2537 precompiles on Hedera/Ethereum.
+contract BLSVerifier {
+    /// Address of BLS12_PAIRING_CHECK precompile.
+    address constant BLS12_PAIRING_CHECK = address(0x0f);
+
+    /// Address of BLS12_MAP_FP2_TO_G2 (used for hash-to-curve message encoding).
+    address constant BLS12_MAP_FP2_TO_G2 = address(0x11);
+
+    /// Verifies that `signature` (G2 point, 256 bytes) was produced by the holder of
+    /// `publicKey` (G1 point, 128 bytes) over the G2-encoded message `messagePoint`
+    /// (256 bytes, typically produced by hash-to-curve onto G2 off-chain or via
+    /// BLS12_MAP_FP2_TO_G2 on-chain).
+    ///
+    /// Pairing check: e(-G1_generator, signature) · e(publicKey, messagePoint) == 1
+    function verify(
+        bytes calldata publicKey,        // 128 bytes, G1 point
+        bytes calldata messagePoint,     // 256 bytes, G2 point
+        bytes calldata signature         // 256 bytes, G2 point
+    ) external view returns (bool valid) {
+        require(publicKey.length    == 128, "bad pubkey len");
+        require(messagePoint.length == 256, "bad msg len");
+        require(signature.length    == 256, "bad sig len");
+
+        // Negated G1 generator (-G1) in EIP-2537's 128-byte encoding: the canonical
+        // BLS12-381 generator's x coordinate, then (p - y), each left-padded to 64 bytes.
+        // As with any cryptographic constant, exercise this contract against the
+        // EIP-2537 test vectors before production use.
+        bytes memory negG1 = hex"0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0f"
+                             hex"c3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+                             hex"00000000000000000000000000000000114d1d6855d545a8aa7d76c8cf2e21f2"
+                             hex"67816aef1db507c96655b9d5caac42364e6f38ba0ecb751bad54dcd6b939c2ca";
+
+        // Build pairing input: (negG1 ‖ signature) ‖ (publicKey ‖ messagePoint) = 768 bytes
+        bytes memory input = bytes.concat(negG1, signature, publicKey, messagePoint);
+
+        bytes memory output = new bytes(32);
+        bool ok;
+        assembly {
+            ok := staticcall(
+                gas(),
+                BLS12_PAIRING_CHECK,
+                add(input, 0x20),
+                768,
+                add(output, 0x20),
+                32
+            )
+        }
+        require(ok, "precompile failed");
+
+        // Pairing check returns 32 bytes: 0x00..01 = valid, 0x00..00 = invalid.
+        valid = (uint256(bytes32(output)) == 1);
+    }
+}
+```
+
+### Example: aggregate two G1 public keys
+
+BLS aggregation is the canonical reason to want native curve precompiles. Adding two G1 public keys lets you combine signatures over the same message into a single signature that verifies against the sum of the keys.
+
+```solidity Solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+contract BLSAggregator {
+    address constant BLS12_G1ADD = address(0x0b);
+
+    /// Adds two G1 points (each 128 bytes). Returns the 128-byte sum.
+    function aggregate(bytes calldata a, bytes calldata b) external view returns (bytes memory sum) {
+        require(a.length == 128 && b.length == 128, "bad point len");
+
+        bytes memory input = bytes.concat(a, b);  // 256 bytes
+        sum = new bytes(128);
+
+        bool ok;
+        assembly {
+            ok := staticcall(gas(), BLS12_G1ADD, add(input, 0x20), 256, add(sum, 0x20), 128)
+        }
+        require(ok, "G1ADD failed");
+    }
+}
+```
+
+> See the [EIP-2537 specification](https://eips.ethereum.org/EIPS/eip-2537) for the full input format of each precompile and the test vectors used to validate implementations.
+
+Reference: [HIP-206](https://hips.hedera.com/hip/hip-206), [HIP-865](https://hips.hedera.com/hip/hip-865), [HIP-1341](https://hips.hedera.com/hip/hip-1341)
 
 ## Operational-Based Throttling
 

--- a/evm/development/json-rpc/index.mdx
+++ b/evm/development/json-rpc/index.mdx
@@ -8,6 +8,31 @@ The [Hiero JSON-RPC Relay](https://github.com/hiero-ledger/hiero-json-rpc-relay)
 
 The Hiero JSON RPC Relay **`msg.value`** uses `18 decimals` when it returns HBAR. As a result, the **`gasPrice`** value returns 18 decimal places since it is only utilized from the JSON RPC Relay. Refer to the [HBAR page](/native/fundamentals/hbars) for a list of Hiero APIs and the decimal places they return.
 
+## Pectra-era transaction & query support
+
+Under the [Pectra hard fork](/evm/development/deploying#pectra-hard-fork) ([HIP-1341](https://hips.hedera.com/hip/hip-1341)), the relay accepts the following transaction types via `eth_sendRawTransaction`:
+
+| Type | Spec                                                        | Notes                                                                                                                    |
+| ---- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `0`  | Legacy ([EIP-155](https://eips.ethereum.org/EIPS/eip-155))  | Pre-Berlin legacy transactions.                                                                                          |
+| `1`  | [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)         | Optional `accessList` to pre-warm storage slots and addresses.                                                           |
+| `2`  | [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)         | `maxFeePerGas` + `maxPriorityFeePerGas`. Priority fee is ignored; Hedera fees are network-determined.                    |
+
+Type 3 (EIP-4844 blob transactions) is rejected. See [HIP-866](https://hips.hedera.com/hip/hip-866). Type 4 ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)) is also rejected: EOA Code Delegation is currently deactivated on Hedera.
+
+### Intrinsic-gas calculation (EIP-7623)
+
+The relay computes intrinsic gas using the Pectra formula, including the calldata floor introduced by [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623):
+
+```plain wrap
+intrinsic_gas = max(
+  21000 + 4 × zero_bytes + 16 × non_zero_bytes,
+  21000 + 10 × (zero_bytes + 4 × non_zero_bytes)         // EIP-7623 floor
+)
+```
+
+This affects `eth_estimateGas`, `eth_call`, and `eth_sendRawTransaction` pre-validation. Most contract calls (where execution gas dominates) are unaffected.
+
 ## JSON RPC Relay Options for the Hedera Network
 
 When interacting with smart contracts on Hedera, developers have several options for setting up a JSON RPC Relay. Each choice comes with unique advantages and trade-offs based on your project's needs, scalability, and operational preferences.
@@ -16,7 +41,7 @@ When interacting with smart contracts on Hedera, developers have several options
 2. [**Self-hosted JSON RPC Relay**](https://github.com/hiero-ledger/hiero-json-rpc-relay/tree/main)**:** Running your own JSON RPC Relay offers complete control over configurations and network selection (testnet, previewnet, mainnet). It is best suited for projects requiring flexibility, high reliability, and scalability, especially in production environments.
 3. [**Third-party JSON RPC Relay Services**](#community-hosted-json-rpc-relays)**:** Several third-party providers offer managed JSON RPC Relay services with different levels of reliability, service-level agreements (SLAs), and fee structures. These services remove infrastructure maintenance overhead, allowing teams to focus more on development (*you can find the list of supported services* [*below*](#community-hosted-json-rpc-relays)*).*
 
-| Feature                       |    Hiero Local Node   | Self-hosted RPC Relay |             Third-party RPC Relay            |
+| Feature                       |    Hiero Local Node   | Self-hosted Relay     |             Third-party RPC Relay            |
 | ----------------------------- | :-------------------: | :-------------------: | :------------------------------------------: |
 | **Infrastructure Management** |        Minimal        |        Required       |                     None                     |
 | **Reliability and Stability** |      High (local)     |          High         |                Variable by SLA               |
@@ -25,7 +50,7 @@ When interacting with smart contracts on Hedera, developers have several options
 | **Ideal Use Case**            | Testing & Development |  Testing & Production | Builders who prefer convenience & Production |
 
 <Check>
-Read the [**JSON RPC Relay Comparison blog**](https://hedera.com/blog/selecting-a-json-rpc-relay-for-your-project) post to learn more about the different options!
+  Read the [**JSON RPC Relay Comparison blog**](https://hedera.com/blog/selecting-a-json-rpc-relay-for-your-project) post to learn more about the different options!
 </Check>
 
 ## Community Hosted JSON-RPC Relays
@@ -34,7 +59,11 @@ Anyone in the community can set up their own JSON RPC relay that applications ca
 
 #### JSON-RPC Relay Endpoints
 
-<table><thead><tr><th>Network</th><th align="center">Chain ID</th><th align="center">Hashio RPC URL</th><th align="center">thirdweb RPC URL</th></tr></thead><tbody><tr><td><strong>Mainnet</strong></td><td align="center"><code>295</code></td><td align="center"><a href="https://mainnet.hashio.io/api">https://mainnet.hashio.io/api</a></td><td align="center"><a href="https://295.rpc.thirdweb.com">https://295.rpc.thirdweb.com</a></td></tr><tr><td><strong>Testnet</strong></td><td align="center"><code>296</code></td><td align="center"><a href="https://testnet.hashio.io/api">https://testnet.hashio.io/api</a></td><td align="center"><a href="https://296.rpc.thirdweb.com">https://296.rpc.thirdweb.com</a></td></tr><tr><td><strong>Previewnet</strong></td><td align="center"><code>297</code></td><td align="center"><a href="https://previewnet.hashio.io/api">https://previewnet.hashio.io/api</a>**</td><td align="center"><a href="https://297.rpc.thirdweb.com">https://297.rpc.thirdweb.com</a></td></tr></tbody></table>
+| Network | Chain ID | Hashio RPC URL | thirdweb RPC URL |
+| --- | :---: | :---: | :---: |
+| **Mainnet** | `295` | [https://mainnet.hashio.io/api](https://mainnet.hashio.io/api) | [https://295.rpc.thirdweb.com](https://295.rpc.thirdweb.com) |
+| **Testnet** | `296` | [https://testnet.hashio.io/api](https://testnet.hashio.io/api) | [https://296.rpc.thirdweb.com](https://296.rpc.thirdweb.com) |
+| **Previewnet** | `297` | [https://previewnet.hashio.io/api](https://previewnet.hashio.io/api) | [https://297.rpc.thirdweb.com](https://297.rpc.thirdweb.com) |
 
 <Check>
 ### 🚨 **PLEASE NOTE**

--- a/evm/differences/index.mdx
+++ b/evm/differences/index.mdx
@@ -34,6 +34,23 @@ Hedera supports jumbo Ethereum transactions (introduced in [HIP-1086](https://hi
 
 ---
 
+## Pectra Compatibility
+
+Hedera adopts the applicable EIPs from Ethereum's Pectra upgrade under [HIP-1341](https://hips.hedera.com/hip/hip-1341), so Ethereum tooling that targets Pectra (Prague EVM execution layer) works on Hedera with no special handling:
+
+| Pectra capability                                                | Supported on Hedera | Notes                                                                                                                                              |
+| ---------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BLS12-381 precompiles** ([EIP-2537](https://eips.ethereum.org/EIPS/eip-2537))              | ✅                  | Seven new precompiles at addresses `0x0b`–`0x11`. Callable via `call`/`staticcall` exactly as on Ethereum. See [Gas and Fees](/evm/development/gas-fees#hedera-system-contract-gas). |
+| **Calldata gas floor** ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623))                  | ✅                  | Same formula: `21000 + 10 × (zero_bytes + 4 × non_zero_bytes)` floor. Most contract calls (where execution gas dominates) are unaffected.         |
+| **EOA Code Delegation** ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702))                 | ❌                  | **Currently deactivated on Hedera.** Type 4 (set-code) transactions are not accepted and no account delegation takes execution effect. |
+| **Blob transactions** ([EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691)) | ❌                  | Hedera does not support blobs ([HIP-866](https://hips.hedera.com/hip/hip-866)). Type 3 transactions are rejected. Use [jumbo EthereumTransactions](#jumbo-ethereum-transactions) for large payloads. |
+
+<Info>
+**EIP-7702 is deactivated.** Hedera runs the Prague EVM, but EIP-7702 (set EOA account code), and therefore EOA Code Delegation, is currently disabled. Type 4 transactions are rejected and account delegations have no execution effect.
+</Info>
+
+---
+
 ## EVM Developers: What Changes on Hedera
 
 The following topics cover the most common differences when coming from Ethereum:

--- a/evm/quickstart/deploy-with-hardhat.mdx
+++ b/evm/quickstart/deploy-with-hardhat.mdx
@@ -253,7 +253,7 @@ The output looks like this:
 ```bash
 ~/projects/hardhat-erc-721-mint-burn >> npx hardhat run scripts/deploy.ts --network testnet
 Compiling your Solidity contracts...
-Compiled 1 Solidity file with solc 0.8.28 (evm target: cancun)
+Compiled 1 Solidity file with solc 0.8.30 (evm target: prague)
 
 Deploying contract with the account: 0xA98556A4deeB07f21f8a66093989078eF86faa30
 Contract deployed at: 0x6035bA3BCa9595637B463Aa514c3a1cE3f67f3de

--- a/evm/tools/hardhat/index.mdx
+++ b/evm/tools/hardhat/index.mdx
@@ -235,7 +235,7 @@ You can build the project using:
 npx hardhat build
 ```
 
-You can run all the tests in your project—both Solidity and TypeScript—using the `test` task:
+You can run all the tests in your project (both Solidity and TypeScript) using the `test` task:
 
 ```bash
 npx hardhat test
@@ -327,7 +327,7 @@ Now, let's go ahead and deploy the contract:
 ```bash
 ~/projects/tutorial-local-hardhat >> npx hardhat run scripts/deploy.ts
 Compiling your Solidity contracts...
-Compiled 1 Solidity file with solc 0.8.28 (evm target: cancun)
+Compiled 1 Solidity file with solc 0.8.30 (evm target: prague)
 
 Deploying contract with the account: 0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69
 Contract deployed at: 0xB3e022eBC7D5C5B1f4ca50b3D4A55173b34ceD49

--- a/evm/tutorials/advanced/erc721-hardhat/part1-mint-burn.mdx
+++ b/evm/tutorials/advanced/erc721-hardhat/part1-mint-burn.mdx
@@ -253,14 +253,14 @@ Deploy your contract by executing the script:
 npx hardhat run scripts/deploy.ts --network testnet
 ```
 
-<Check>Copy the deployed address—you'll need this in subsequent steps.</Check>
+<Check>Copy the deployed address; you'll need this in subsequent steps.</Check>
 
 The output looks like this:
 
 ```bash
 ~/projects/hardhat-erc-721-mint-burn >> npx hardhat run scripts/deploy.ts --network testnet
 Compiling your Solidity contracts...
-Compiled 1 Solidity file with solc 0.8.28 (evm target: cancun)
+Compiled 1 Solidity file with solc 0.8.30 (evm target: prague)
 
 Deploying contract with the account: 0xA98556A4deeB07f21f8a66093989078eF86faa30
 Contract deployed at: 0x6035bA3BCa9595637B463Aa514c3a1cE3f67f3de

--- a/native/smart-contracts/ethereum-transaction.mdx
+++ b/native/smart-contracts/ethereum-transaction.mdx
@@ -4,7 +4,7 @@ description: "Execute raw RLP-encoded EVM transactions on Hedera with `EthereumT
 ---
 
 
-An `EthereumTransaction` lets you execute a raw, RLP-encoded EVM transaction (**type 0, 1, 2, or 4**) on the Hedera network. This enables developers familiar with EVM tooling to leverage their existing knowledge and infrastructure when interacting with the [Hedera Smart Contract Service (HSCS)](/evm/tutorials).
+An `EthereumTransaction` lets you execute a raw, RLP-encoded EVM transaction (**type 0, 1, or 2**) on the Hedera network. This enables developers familiar with EVM tooling to leverage their existing knowledge and infrastructure when interacting with the [Hedera Smart Contract Service (HSCS)](/evm/tutorials).
 
 ## Supported transaction types
 

--- a/native/smart-contracts/ethereum-transaction.mdx
+++ b/native/smart-contracts/ethereum-transaction.mdx
@@ -1,11 +1,22 @@
 ---
 title: "Ethereum transaction"
+description: "Execute raw RLP-encoded EVM transactions on Hedera with `EthereumTransaction`, including call data via HFS file ID and max gas allowance settings."
 ---
 
 
-An `EthereumTransaction` lets you execute a raw, RLP-encoded (type 0, 1, or 2) Ethereum transaction on the Hedera network. This enables developers familiar with EVM tooling to leverage their existing knowledge and infrastructure when interacting with the [Hedera Smart Contract Service (HSCS)](/evm/tutorials).
+An `EthereumTransaction` lets you execute a raw, RLP-encoded EVM transaction (**type 0, 1, 2, or 4**) on the Hedera network. This enables developers familiar with EVM tooling to leverage their existing knowledge and infrastructure when interacting with the [Hedera Smart Contract Service (HSCS)](/evm/tutorials).
 
-<Warning>
+## Supported transaction types
+
+| Type  | Spec                                                          | Use it when…                                                                                                                              
+| :---: | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`   | Legacy ([EIP-155](https://eips.ethereum.org/EIPS/eip-155))    | You need maximum compatibility with older tooling. No `access_list`, no priority fee.                                                                                                                                                                         |
+| `1`   | [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)           | You want to pre-warm storage slots / addresses via an [`access_list`](#access-lists-eip-2930) to reduce execution gas.                                                                                                                                        |                                                                        
+| `2`   | [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)           | The default for most modern wallets. Carries `max_fee_per_gas` + `max_priority_fee_per_gas` (priority fee is ignored; Hedera fees are network-determined).                                                                                                    |
+
+Type 3 (blob transactions per [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)) is **not supported** on Hedera. See [HIP-866](https://hips.hedera.com/hip/hip-866). For large `callData`, use [jumbo `EthereumTransaction` payloads](#handling-large-calldata-payloads) ([HIP-1086](https://hips.hedera.com/hip/hip-1086)) instead. Type 4 ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)) is also **not accepted**: EOA Code Delegation is currently deactivated on Hedera.  
+
+<Warning> 
 #### **Important**
 
 Hedera interprets HBAR decimals differently depending on the context:
@@ -17,7 +28,110 @@ Hedera interprets HBAR decimals differently depending on the context:
   Reference: [HIP-410](https://hips.hedera.com/hip/hip-410)
 </Warning>
 
-<table><thead><tr><th>Field</th><th>Description</th></tr></thead><tbody><tr><td><strong>Ethereum Data</strong></td><td>An RLP-encoded (type 0, 1, or 2) Ethereum transaction to execute on the Hedera network. This enables developers to leverage existing EVM tooling and workflows with the Hedera Smart Contract Service (HSCS).</td></tr><tr><td><strong>Call Data File ID</strong></td><td>An optional field referencing a file on the Hedera File Service (HFS) containing the <code>callData</code>. When set, the network ignores the <code>callData</code> in <code>ethereumData</code> during execution and instead loads the data from the referenced file. However, the full <code>callData</code> must still be present in the originally signed <code>ethereumData</code> for signature validation. In this case, <code>ethereumData</code> will contain a placeholder where <code>callData</code> normally resides, and the transaction must be "rehydrated" with the HFS content during validation.<br/><br/><em><strong>Note:</strong> With</em> <a href="https://hips.hedera.com/hip/hip-1086"><em>HIP-1086</em></a><em>, jumbo <code>ethereumData</code> is the preferred approach for large payloads, but <code>callDataFileId</code> remains supported for oversized payloads or legacy workflows.</em></td></tr><tr><td><strong>Max Allowance</strong></td><td><p>The maximum amount of HBAR (specified in <strong>tinybars</strong>) the payer is willing to cover for the gas consumed during transaction execution. This value acts as a ceiling if the actual gas cost (determined by <code>gasLimit</code> in the RLP-encoded transaction and the network's gas price) exceeds this amount, the transaction fails.<br/></p><p>Ordinarily, the account with the ECDSA alias extracted from the <code>ethereumData</code> signature covers the execution fees. If insufficient fees are authorized by that account, the payer can be charged up to but not exceeding <code>maxGasAllowance</code>. If the authorized fee is zero, the payer is charged the full amount.</p></td></tr></tbody></table>
+| Field | Description |
+| --- | --- |
+| **Ethereum Data** | An RLP-encoded (type 0, 1, or 2) Ethereum transaction to execute on the Hedera network. This enables developers to leverage existing EVM tooling and workflows with the Hedera Smart Contract Service (HSCS). |
+| **Call Data File ID** | An optional field referencing a file on the Hedera File Service (HFS) containing the `callData`. When set, the network ignores the `callData` in `ethereumData` during execution and instead loads the data from the referenced file. However, the full `callData` must still be present in the originally signed `ethereumData` for signature validation. In this case, `ethereumData` will contain a placeholder where `callData` normally resides, and the transaction must be "rehydrated" with the HFS content during validation.<br/><br/>***Note:** With* [*HIP-1086*](https://hips.hedera.com/hip/hip-1086)*, jumbo `ethereumData` is the preferred approach for large payloads, but `callDataFileId` remains supported for oversized payloads or legacy workflows.* |
+| **Max Allowance** | The maximum amount of HBAR (specified in **tinybars**) the payer is willing to cover for the gas consumed during transaction execution. This value acts as a ceiling if the actual gas cost (determined by `gasLimit` in the RLP-encoded transaction and the network's gas price) exceeds this amount, the transaction fails.<br/><br/>Ordinarily, the account with the ECDSA alias extracted from the `ethereumData` signature covers the execution fees. If insufficient fees are authorized by that account, the payer can be charged up to but not exceeding `maxGasAllowance`. If the authorized fee is zero, the payer is charged the full amount. |
+
+## Access Lists (EIP-2930)
+
+Type 1 and Type 2 transactions accept an optional `access_list`, a list of `{address, storageKeys[]}` tuples that the EVM "warms up" before execution. Slots and addresses on the list are charged at the warm rate (`100` gas) on first touch instead of the cold rate (`2,100` for storage, `2,600` for accounts).
+
+```plain wrap
+access_list = [
+  { address: "0x<contract>", storageKeys: ["0x<slot1>", "0x<slot2>", ...] },
+  { address: "0x<another>",  storageKeys: [] },
+  ...
+]
+```
+
+**When access lists save gas:**
+
+- Cross-contract calls where the EVM doesn't already know about the target address. Listing it converts a 2,600-gas cold `CALL` into a 100-gas warm one.
+- Reads of storage slots in another contract (a token balance lookup, a registry probe). Listing the slot converts a 2,100-gas cold `SLOAD` into a 100-gas warm one.
+
+**When they don't save gas:**
+
+- Slots in the contract that owns the transaction's `to` address are warm anyway (the contract's own storage is pre-warmed).
+- Speculative listings of slots that never get read. You still pay the access-list overhead (`2,400` per address + `1,900` per slot) without recouping the cold-access discount.
+
+### Example: hand-built Type 1 transaction (ethers v6)
+
+```javascript wrap JavaScript 
+import { Wallet, JsonRpcProvider, Transaction } from "ethers";
+
+const provider = new JsonRpcProvider("https://testnet.hashio.io/api");
+const wallet   = new Wallet(process.env.OPERATOR_KEY, provider);
+
+const tx = new Transaction();
+tx.type     = 1;                               // EIP-2930
+tx.chainId  = 296n;                            // Hedera testnet
+tx.to       = "0x<router-address>";
+tx.value    = 0n;
+tx.gasLimit = 200_000n;
+tx.gasPrice = (await provider.getFeeData()).gasPrice;
+tx.nonce    = await provider.getTransactionCount(wallet.address);
+tx.data     = "0x<encoded-call-data>";
+tx.accessList = [
+  {
+    address: "0x<token-contract>",
+    storageKeys: [
+      // balanceOf slot
+      "0x0000000000000000000000000000000000000000000000000000000000000003",
+      // allowance slot
+      "0x0000000000000000000000000000000000000000000000000000000000000004", 
+    ],
+  },
+];
+
+const signed = await wallet.signTransaction(tx);
+const sent   = await provider.broadcastTransaction(signed);
+console.log("tx hash:", sent.hash);
+```
+
+The same payload can be submitted via `EthereumTransaction` directly by passing the raw signed RLP bytes as `ethereumData`.
+
+### Example: Type 2 with access list (viem)
+
+```javascript wrap JavaScript
+import { createWalletClient, http, parseGwei } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { hederaTestnet } from "viem/chains";
+
+const account = privateKeyToAccount(process.env.OPERATOR_KEY);
+const client  = createWalletClient({ chain: hederaTestnet, transport: http(), account });
+
+const hash = await client.sendTransaction({
+  type: "eip1559",
+  to: "0x<router-address>",
+  data: "0x<encoded-call-data>",
+  // example value; query eth_gasPrice for the live rate (Hedera's gas price is network-determined)
+  maxFeePerGas: parseGwei("710"), 
+  // ignored on Hedera; fees are network-determined
+  maxPriorityFeePerGas: 0n,       
+  accessList: [
+    {
+      address: "0x<token-contract>",
+      storageKeys: [
+        "0x0000000000000000000000000000000000000000000000000000000000000003",
+      ],
+    },
+  ],
+});
+```
+
+> **Tip:** Most JSON-RPC providers expose `eth_createAccessList`; call it against a simulated transaction to get a near-optimal access list before signing.
+
+#### Hedera specifics
+
+A few things to know before you rely on access lists on Hedera:
+
+- **The warm/cold discount is honored.** Hedera applies the same EIP-2929/2930 gas accounting as Ethereum, so listed addresses and slots are charged at the warm rate on first touch. The exact cold/warm opcode costs are in the [gas schedule](/evm/development/gas-fees#evm-opcode-gas).
+- **Access-list bytes count toward the EIP-7623 calldata floor.** A large speculative access list increases `callData` size and can push a low-execution transaction into the [calldata floor](/evm/development/gas-fees#intrinsic-gas); list only slots you'll actually touch.
+- **Submitting via the SDK.** Pass the raw signed RLP (Type 1 or Type 2) as `ethereumData` on an `EthereumTransaction`; Hedera preserves the access list during execution. No Hedera-native field mirrors `access_list`; it lives entirely inside the RLP payload.
+
+***
 
 ## Handling Large callData Payloads
 
@@ -37,7 +151,13 @@ This is added to base gas and execution gas. Developers must ensure both `gasLim
 
 #### **Quick reference: Jumbo vs Standard Transactions**
 
-<table><thead><tr><th>Feature</th><th>Jumbo Ethereum Transaction</th><th>Standard Ethereum Transaction</th></tr></thead><tbody><tr><td><strong>callData Size Limit</strong></td><td>24KB (creation) / 128KB (call)</td><td>~6KB total transaction size</td></tr><tr><td><strong>callDataFileId Needed?</strong></td><td>Only if limits exceeded</td><td>Always for large payloads</td></tr><tr><td><strong>Gas Calculation</strong></td><td>Always for large payloads</td><td>Same</td></tr><tr><td><strong>Batch Inclusion</strong></td><td>Not supported</td><td>Supported</td></tr><tr><td><strong>Network Throttling</strong></td><td>Dedicated throttle bucket</td><td>Standard throttling</td></tr></tbody></table>
+| Feature | Jumbo Ethereum Transaction | Standard Ethereum Transaction |
+| --- | --- | --- |
+| **callData Size Limit** | 24KB (creation) / 128KB (call) | ~6KB total transaction size |
+| **callDataFileId Needed?** | Only if limits exceeded | Always for large payloads |
+| **Gas Calculation** | Always for large payloads | Same |
+| **Batch Inclusion** | Not supported | Supported |
+| **Network Throttling** | Dedicated throttle bucket | Standard throttling |
 
 📣 *See* [*HIP-1086*](https://hips.hedera.com/hip/hip-1086) *and the* [*Gas and Fees page*](/evm/development/gas-fees#gas-schedule-and-fee-calculation) *for complete technical details.*
 
@@ -69,7 +189,7 @@ The total transaction cost includes:
 
 <CodeGroup>
 
-```java Java
+```java wrap Java
 //Create the transaction
 EthereumTransaction transaction = new EthereumTransaction()
      .setEthereumData(ethereumData)
@@ -90,7 +210,7 @@ System.out.println("The transaction consensus status is " +transactionStatus);
 ```
 
 
-```javascript JavaScript
+```javascript wrap JavaScript
 //Create the transaction
 const transaction = new EthereumTransaction()
      .setEthereumData(ethereumData)
@@ -111,7 +231,7 @@ console.log("The transaction consensus status is " +transactionStatus);
 ```
 
 
-```go Go
+```go wrap Go
 //Create the transaction
 transaction, err := hedera.NewEthereumTransaction().
      SetEthereumData(ethereumData)

--- a/networks/release-notes/services.mdx
+++ b/networks/release-notes/services.mdx
@@ -13,8 +13,6 @@ Visit the [Hedera status page](https://status.hedera.com/) for the latest versio
   **TESTNET UPDATED: JUNE 25, 2026**
 </Check>
 
-<!-- highlights: TODO - add a "### Release highlights" paragraph and a "What's new in Release v0.75?" accordion above the build block -->
-
 ### [**Build 0.75.1**](https://github.com/hiero-ledger/hiero-consensus-node/releases/tag/v0.75.1)
 
 <Accordion title="What's Changed">
@@ -120,7 +118,7 @@ Visit the [Hedera status page](https://status.hedera.com/) for the latest versio
   * stabilize GetScheduledInfoTest non-existent schedule tests by using virtual time [#25073](https://github.com/hiero-ledger/hiero-consensus-node/pull/25073) by [@AlexKehayov](https://github.com/AlexKehayov)
   * use lenient stubs for race-dependent watchKey mocks in testConfigWatcher_randomError [#25072](https://github.com/hiero-ledger/hiero-consensus-node/pull/25072) by [@AlexKehayov](https://github.com/AlexKehayov)
   * prevent hollow account fuzzing test to fail due to stale account registry entries [#25056](https://github.com/hiero-ledger/hiero-consensus-node/pull/25056) by [@Evdokia-Georgieva](https://github.com/Evdokia-Georgieva)
-  * isolate HAPI subtask logs into per-task subdirectories, regroup subtasks in sets of <30mins (#24888, #24880) by [@AlexKehayov](https://github.com/AlexKehayov)
+  * isolate HAPI subtask logs into per-task subdirectories, regroup subtasks in sets of \<#24888, #24880 by [@AlexKehayov](https://github.com/AlexKehayov)
   * stabilize blck001...004ReturnsCorrectBlockProperties by not deferring first call's status [#25031](https://github.com/hiero-ledger/hiero-consensus-node/pull/25031) by [@AlexKehayov](https://github.com/AlexKehayov)
   * ensure xfersScenario transfers reach consensus before record assertion [#25057](https://github.com/hiero-ledger/hiero-consensus-node/pull/25057) by [@AlexKehayov](https://github.com/AlexKehayov)
   * 25065 Decrease log level for CompactionV3 log statements [#25066](https://github.com/hiero-ledger/hiero-consensus-node/pull/25066) by [@imalygin](https://github.com/imalygin)

--- a/smart-contract-verification-api.yaml
+++ b/smart-contract-verification-api.yaml
@@ -113,7 +113,7 @@ paths:
                         content: "\nnumber: public(uint256)\n\n@external\ndef __init__():\n    self.number = 0\n\n@external\ndef setNumber(newNumber: uint256):\n    self.number = newNumber\n\n@view\n@external\ndef getNumber() -> uint256:\n    return self.number\n"
                     settings:
                       optimize: gas
-                      evmVersion: cancun
+                      evmVersion: prague
                   compilerVersion: 0.3.10+commit.91361694
                   contractIdentifier: MyVyperContract.vy:MyVyperContract
                   creationTransactionHash: '0xb6ee9d528b336942dd70d3b41e2811be10a473776352009fd73f85604f5ed206'
@@ -125,7 +125,7 @@ paths:
                       test.vy:
                         content: "\na: public(uint256)\nb: public(uint256)\n\n@deploy\ndef __init__():\n    self.a = 1\n    self.b = 2\n"
                     settings:
-                      evmVersion: cancun
+                      evmVersion: prague
                     storage_layout_overrides:
                       test.vy:
                         a:


### PR DESCRIPTION
**Description**:
updates evm docs for hedera's pectra hard fork adoption (hip-1341).

- deploying.mdx — pectra hard fork section, eip table, supported tx types, cancun→pectra migration guide
- gas-fees.mdx — eip-7623 calldata floor, bls12-381 precompile table (0x0b–0x11) with solidity examples, gas limit table updated to "pectra cost"
- json-rpc/index.mdx — pectra tx types and eip-7623 intrinsic gas formula
- differences/index.mdx — pectra compatibility table (bls, calldata floor, eip-7702 deactivated, blobs)
- ethereum-transaction.mdx — supported tx types table, access lists (eip-2930) section with ethers v6 + viem examples
- hardhat quickstart/tools/erc-721 tutorial — solc bumped to 0.8.30/prague

**note**: eip-7702 (eoa code delegation) is currently deactivated on hedera; type 4 transactions are not accepted.

**Related issue(s)**:

Fixes #444

