### PR TITLE
docs(evm): clarify HBAR native value is tinybar inside the EVM (8 vs 18 decimals)

### DIFF
--- a/evm/development/deploying.mdx
+++ b/evm/development/deploying.mdx
@@ -133,7 +133,7 @@ In Ethereum, these functions act as "catch-all" mechanisms when a contract recei
 #### Impacted Variables
 
 * **`msg.sender`:** The address initiating the contract call.
-* **`msg.value`:** The amount of HBAR sent along with the call.
+* **`msg.value`:** The HBAR sent along with the call, in **tinybar** (8 decimals) — not wei. A 1 HBAR transfer is `msg.value == 1e8`. See [Decimal Handling](/evm/differences/hbar-decimals).
 
 #### Key Points
 

--- a/evm/development/troubleshooting.mdx
+++ b/evm/development/troubleshooting.mdx
@@ -11,14 +11,19 @@ Hedera is EVM-compatible, but a few things behave differently than Ethereum, and
 
 ### Decimal handling: 8 vs 18
 
-The native Hedera ledger uses 8 decimals for HBAR (1 ℏ = 10⁸ tinybars). The JSON-RPC relay scales values up to 18 decimals so they match Ethereum's `wei` convention. Inside an EVM contract, `msg.value`, `balance`, and `gasPrice` all use 18 decimals; the relay handles the conversion. The trap is when you mix native SDK calls and EVM contract calls in the same flow. You have to do the conversion yourself there, and the off-by-`10**10` bug is easy to write.
+The native Hedera ledger uses 8 decimals for HBAR (1 ℏ = 10⁸ tinybars); Ethereum tooling uses 18-decimal `wei`. The JSON-RPC relay converts a transaction's `value` and `gasPrice` from 18-decimal weibar to 8-decimal tinybar **before** the EVM runs — so **inside a contract, `msg.value`, `address(this).balance`, and the `value` in `call`/`send`/`transfer` are all tinybar (8 decimals), not wei.** Two traps:
+
+* Don't assume `msg.value` is wei — a 1 HBAR transfer arrives as `msg.value == 1e8`, not `1e18`.
+* Contract-to-contract calls are **not** converted: `call{value: 1 ether}` sends `1e18` *as tinybar* (which exceeds the total HBAR supply and reverts). Use tinybar amounts — 1 HBAR = `1e8`.
 
 ```solidity
-// Inside a contract, msg.value is in 18-decimal wei (as on Ethereum).
+// msg.value is TINYBAR inside the contract: 1 HBAR = 1e8, not 1 ether (1e18).
 function deposit() external payable {
-    require(msg.value >= 1 ether, "send at least 1 HBAR");
+    require(msg.value >= 1e8, "send at least 1 HBAR"); // 1e8 tinybar = 1 HBAR
 }
 ```
+
+See [Decimal Handling](/evm/differences/hbar-decimals) for the full explanation.
 
 ### HBAR transfers don't always trigger `receive()`
 

--- a/evm/differences/hbar-decimals.mdx
+++ b/evm/differences/hbar-decimals.mdx
@@ -13,13 +13,28 @@ Managing token decimals is critical when working with HBAR, HTS tokens, and ERC 
 
 The table below compares the decimal handling of HBAR, HTS tokens, and ERC tokens on Hedera, incorporating details about their representation across APIs and services. This overview highlights differences in precision and context.
 
-<table><thead><tr><th>API/Service</th><th>Decimals</th><th>Explanation</th></tr></thead><tbody><tr><td><strong>Hedera API (HAPI)</strong></td><td>8 decimals</td><td>HBAR is represented with 8 decimal places, aligning with its native smallest unit tinybar.</td></tr><tr><td><strong>Hedera Smart Contract Service</strong></td><td>8 decimals</td><td>Within the EVM environment, HBAR maintains 8 decimal places, consistent with its native representation.</td></tr><tr><td><strong>JSON-RPC Relay (Arguments)</strong></td><td>8 decimals</td><td>When HBAR values are passed as arguments in JSON-RPC calls, they are represented with 8 decimal places.</td></tr><tr><td><strong>JSON-RPC Relay (<code>msg.value</code>)</strong></td><td>18 decimals</td><td>For compatibility with EVM tooling, <code>msg.value</code> in JSON-RPC Relay represents HBAR with 18 decimal places. Consequently, <code>gasPrice</code> also uses 18 decimal places in this context.</td></tr><tr><td><strong>HTS Tokens</strong></td><td>Configurable (up to 8 decimals)</td><td>HTS tokens allow token creators to define precision at token creation, offering flexibility for various use cases.</td></tr><tr><td><strong>ERC Tokens</strong></td><td>Default 18 decimals</td><td>ERC tokens on Hedera follow Ethereum token standards, with 18 decimals as the default unless specified otherwise.</td></tr></tbody></table>
+<table><thead><tr><th>API/Service</th><th>Decimals</th><th>Explanation</th></tr></thead><tbody><tr><td><strong>Hedera API (HAPI)</strong></td><td>8 decimals</td><td>HBAR is represented with 8 decimal places, aligning with its native smallest unit tinybar.</td></tr><tr><td><strong>Hedera Smart Contract Service (EVM execution)</strong></td><td>8 decimals</td><td>Within the EVM, HBAR is tinybar-scaled: <code>msg.value</code>, <code>address(this).balance</code>, and the <code>value</code> passed to <code>call</code>/<code>send</code>/<code>transfer</code> are all 8 decimals during execution.</td></tr><tr><td><strong>JSON-RPC Relay (Arguments)</strong></td><td>8 decimals</td><td>When HBAR values are passed as arguments in JSON-RPC calls, they are represented with 8 decimal places.</td></tr><tr><td><strong>JSON-RPC Relay (<code>msg.value</code> / <code>gasPrice</code>) — RPC boundary only</strong></td><td>18 decimals</td><td>Ethereum tooling submits and reads the transaction <code>value</code> and <code>gasPrice</code> in 18-decimal weibar at the JSON-RPC boundary. <strong>The relay converts weibar to tinybar (÷10<sup>10</sup>) before the EVM executes</strong>, so the <code>msg.value</code> your contract actually sees is 8-decimal tinybar — not 18-decimal wei. See the warning below.</td></tr><tr><td><strong>HTS Tokens</strong></td><td>Configurable (up to 8 decimals)</td><td>HTS tokens allow token creators to define precision at token creation, offering flexibility for various use cases.</td></tr><tr><td><strong>ERC Tokens</strong></td><td>Default 18 decimals</td><td>ERC tokens on Hedera follow Ethereum token standards, with 18 decimals as the default unless specified otherwise.</td></tr></tbody></table>
 
 **Key Impacts**:
 
 * Account for scaling differences when converting HBAR between APIs, especially when using JSON-RPC.
 * HBAR fees are always calculated in tinybars, regardless of the API or service used.
-* JSON-RPC’s use of 18 decimals ensures smooth integration with EVM tools and libraries.
+* The 18-decimal representation is a **JSON-RPC boundary convention only** — inside the EVM, native value is tinybar (8 decimals). Do not assume `msg.value` is wei-scale (see warning).
+
+<Warning>
+**Inside a contract, native value is tinybar (8 decimals), not wei (18).** `msg.value`, `address(this).balance`, and the `value` you pass to `call`/`send`/`transfer` are all tinybar-denominated during EVM execution. Two cases to design for:
+
+- **Transactions from tooling (relay path).** When you send 1 HBAR as `value: 1 ether` (1e18 weibar), the relay divides by 10<sup>10</sup>, so your contract sees `msg.value == 1e8`. A contract that stores `msg.value` — e.g. a WETH-style wrapper reporting `decimals() = 18` — will record a balance 10<sup>10</sup> smaller than an Ethereum developer would expect.
+- **Contract-to-contract calls (no conversion).** `payable(x).call{value: 1 ether}("")` compiles `1 ether` to `1e18` and sends it **as tinybar** (= 10<sup>10</sup> HBAR), which either reverts (insufficient balance) or over-transfers. Specify the value in tinybar instead.
+
+```solidity
+// ❌ BROKEN — `1 ether` compiles to 1e18 and is treated as tinybar (= 10^10 HBAR)
+(bool ok, ) = payable(vault).call{value: 1 ether}("");
+
+// ✅ CORRECT — specify the value in tinybar (1 HBAR = 100,000,000 tinybar)
+(bool ok, ) = payable(vault).call{value: 100000000}("");
+```
+</Warning>
 
 ***
 

--- a/evm/differences/native-token-transfers.mdx
+++ b/evm/differences/native-token-transfers.mdx
@@ -7,7 +7,7 @@ title: "Handling HBAR Transfers in Contracts"
 
 On Ethereum, sending ETH to a contract address automatically triggers the `receive()` or `fallback()` functions, allowing contracts to process incoming funds. On Hedera, these functions also exist but require HBAR to be explicitly sent via `contractCall` for them to execute. Direct HBAR transfers to a contract’s Hedera account won’t trigger any logic unless additional steps are taken.
 
-Fortunately, the core Solidity patterns—like using `transfer()`, `send()`, or `call()`—work the same way on Hedera, making it easy for developers familiar with EVM. This guide highlights these mechanisms, details the key Hedera-specific considerations, and provides examples to help you handle HBAR transfers in your smart contracts
+The core Solidity patterns—`transfer()`, `send()`, and `call()`—are supported on Hedera, with **one important difference: the `value` (and `msg.value`) is denominated in tinybar (8 decimals) during EVM execution, not wei (18 decimals).** This guide highlights these mechanisms, details the key Hedera-specific considerations, and provides examples to help you handle HBAR transfers in your smart contracts.
 
 ### **Sending to Contract**
 
@@ -24,6 +24,10 @@ These methods are supported on Hedera, ensuring compatibility with existing Soli
 * **Fallback and Receive Functions**: When sending HBAR to a contract address via `contractCall`, Hedera behaves like Ethereum. If `receive()` or `fallback()` functions are defined in the contract, they will be triggered upon receipt of HBAR.
 * **Important Note**: Directly transferring HBAR to a contract’s Hedera account (not via `contractCall`) will not trigger these functions. To execute logic upon receipt, ensure transfers occur within the EVM environment.
 
+<Warning>
+**The `value` in `transfer`/`send`/`call` is tinybar (8 decimals), not wei (18).** In the examples below, `_amount` is a tinybar amount — `1 HBAR = 100_000_000`. Passing an Ethereum-style `1 ether` or a wei-scale number sends that number **as tinybar**, over- or under-transferring by 10<sup>10</sup> (it will revert on insufficient balance, or drain far more than intended). Use tinybar literals, or convert with the helpers in [Decimal Handling](/evm/differences/hbar-decimals).
+</Warning>
+
 ***
 
 ## Example Contract Functions for HBAR Transfers
@@ -37,7 +41,8 @@ receive() external payable {
     emit HbarReceived(msg.sender, msg.value);
 }
 
-// Transfer HBAR using different methods
+// Transfer HBAR using different methods.
+// NOTE: `_amount` is in TINYBAR (8 decimals), not wei — 1 HBAR = 100_000_000.
 function transferHbar(address payable _receiverAddress, uint _amount) public {
     _receiverAddress.transfer(_amount);
 }

--- a/evm/tokens/whbar.mdx
+++ b/evm/tokens/whbar.mdx
@@ -36,19 +36,20 @@ Developers can integrate WHBAR into their applications by leveraging the followi
 To convert HBAR into its ERC20 representation (WHBAR), use the `deposit()` function. Keep in mind that:
 
 * **Native HBAR:** Uses **8** decimal places (**tinybars**).
-* **WHBAR (ERC20):** Uses **8** decimal places (**tinybars**)and *ONLY for deposits* (wrapping) uses 18 decimal places (weibars).
+* **WHBAR (ERC20):** Uses **8** decimal places (**tinybars**) throughout — balances, transfers, `deposit()`, and `withdraw()`. `deposit()` simply mints an amount of WHBAR equal to the `msg.value` it receives, and `msg.value` is tinybar during EVM execution. The 18-decimal weibar form is **only** the transaction `value` an *off-chain* caller submits; the relay converts it to tinybar before `deposit()` runs.
 
-The conversion from HBAR to WHBAR involves adjusting for these decimal differences. For example, to wrap native HBAR into WHBAR, call `deposit()` and send your HBAR as `msg.value` in weibars (10¹⁸ per HBAR):
+How you specify the value depends on **who calls `deposit()`**:
+
+* **From off-chain tooling (ethers/viem/wallet):** set the transaction `value` in **weibar** (10¹⁸ per HBAR). The relay converts it to tinybar, so sending `10 * 10**18` weibar wraps 10 HBAR → 10 WHBAR.
+* **From another contract:** the `value` is **tinybar** (no conversion) — use `10 * 10**8` for 10 HBAR. Passing `10 * 10**18` here would send 10¹⁸ tinybar, which exceeds the total HBAR supply and reverts.
 
 ```solidity wrap
 /**
- * @notice Deposits HBAR and mints an equivalent amount of WHBAR
- * @dev This is the only supported method for obtaining WHBAR
+ * @notice Wrap 10 HBAR into WHBAR from within a contract.
+ * @dev Contract-to-contract `value` is TINYBAR (8 decimals): 1 HBAR = 1e8.
  */
-function deposit() public payable {
-    // To wrap 10 HBAR into WHBAR
-    // Note: 1 HBAR = 10^18 weibars; conversion handles the decimal difference.
-    whbarContract.deposit{value: 10 * 10**18}();
+function wrapTenHbar() public {
+    whbarContract.deposit{value: 10 * 10**8}(); // 10 HBAR
 }
 ```
 
@@ -76,10 +77,10 @@ This burns 5 WHBAR and sends back 5 HBAR to the wallet.
 
 When depositing HBAR, remember the conversion nuances between decimal places.
 
-* **Native HBAR & WHBAR Token:** 8 decimals (tinybars).
-* **RPC `msg.value`:** 18 decimals (weibars).
+* **Native HBAR & WHBAR token:** 8 decimals (tinybars) — including `msg.value` inside `deposit()`.
+* **Transaction `value` from an off-chain caller:** 18 decimals (weibars), which the relay converts to tinybar before execution.
 
-Although the `deposit()` function requires input in 18 decimal weibars, WHBAR tokens and all related transfers and balances use 8 decimals, identical to native HBAR in tinybars.
+`deposit()` mints WHBAR equal to `msg.value`, and `msg.value` is **tinybar** during execution — WHBAR is 8-decimal throughout. The 18-decimal weibar form applies only to the `value` an *off-chain* caller puts in the transaction; a **contract** calling `deposit{value: X}` must pass tinybar (1 HBAR = `1e8`).
 </Check>
 
 ***

--- a/evm/tutorials/intermediate/send-receive-hbar.mdx
+++ b/evm/tutorials/intermediate/send-receive-hbar.mdx
@@ -190,6 +190,10 @@ async function contractDeployFcn(bytecode, gasLim) {
 
 ## **Getting HBAR to the Contract**
 
+<Warning>
+Inside the contract, `msg.value` and the `_amount` passed to `transfer`/`send`/`call` are in **tinybar** (8 decimals), not wei — `1 HBAR = 100_000_000`. That's why the `tokenAssociate` guard above uses `require(msg.value > 2000000000, …)` (≈20 HBAR in tinybar). Don't pass `1 ether`/wei-scale values here. See [Decimal Handling](/evm/differences/hbar-decimals).
+</Warning>
+
 ### **The receive/fallback** Functions
 
 In this scenario, you (Operator) transfer 10 HBAR to the contract by triggering either the **_receive_** or **_fallback_** functions of the contract. As described in this [Solidity by Example](https://solidity-by-example.org/sending-ether/) page, the **_receive_** function is called when **_msg.data_** is empty, otherwise the **_fallback_** function is called.


### PR DESCRIPTION
### What

Clarifies Hedera's decimal-handling docs, which imply `msg.value` is 18-decimal *wei* inside a contract — contradicting the same table's row stating the Smart Contract Service uses 8 decimals, and leading developers into a 10^10 scaling error. This aligns six pages to the verified behavior.

### Verified behavior (all pages now reflect this)

Inside the EVM, `msg.value`, `address(this).balance`, and the `value` passed to `call`/`send`/`transfer` are **tinybar (8 decimals)**. The JSON-RPC relay converts only the transaction envelope (weibar → tinybar, ÷10^10) **before** execution; **contract-to-contract** calls are **not** converted. Confirmed against `WHBAR.sol` (`deposit()` mints `msg.value`; `decimals = 8`), a WETH differential test, and the consensus-node value-handling path.

---

### Changes (before → after)

#### 1. `evm/differences/hbar-decimals.mdx`

**Table — Smart Contract Service row**
- **Before:** `Hedera Smart Contract Service | 8 decimals | Within the EVM environment, HBAR maintains 8 decimal places, consistent with its native representation.`
- **After:** `Hedera Smart Contract Service (EVM execution) | 8 decimals | Within the EVM, HBAR is tinybar-scaled: msg.value, address(this).balance, and the value passed to call/send/transfer are all 8 decimals during execution.`

**Table — msg.value row**
- **Before:** `JSON-RPC Relay (msg.value) | 18 decimals | For compatibility with EVM tooling, msg.value in JSON-RPC Relay represents HBAR with 18 decimal places. Consequently, gasPrice also uses 18 decimal places in this context.`
- **After:** `JSON-RPC Relay (msg.value / gasPrice) — RPC boundary only | 18 decimals | Ethereum tooling submits and reads the transaction value and gasPrice in 18-decimal weibar at the JSON-RPC boundary. The relay converts weibar to tinybar (÷10^10) before the EVM executes, so the msg.value your contract actually sees is 8-decimal tinybar — not 18-decimal wei. See the warning below.`

**Key Impacts — 3rd bullet**
- **Before:** `JSON-RPC's use of 18 decimals ensures smooth integration with EVM tools and libraries.`
- **After:** `The 18-decimal representation is a JSON-RPC boundary convention only — inside the EVM, native value is tinybar (8 decimals). Do not assume msg.value is wei-scale (see warning).`

**Added — `<Warning>` block (new):** inside a contract, native value is tinybar (8 decimals), not wei (18); covers the relay-path under-count and the contract-to-contract case, with a broken-vs-correct example:
```solidity
// ❌ BROKEN — `1 ether` (1e18) treated as tinybar (= 10^10 HBAR)
(bool ok, ) = payable(vault).call{value: 1 ether}("");
// ✅ CORRECT — tinybar (1 HBAR = 100,000,000)
(bool ok, ) = payable(vault).call{value: 100000000}("");
```

#### 2. `evm/differences/native-token-transfers.mdx`

**Intro sentence**
- **Before:** `Fortunately, the core Solidity patterns—like using transfer(), send(), or call()—work the same way on Hedera, making it easy for developers familiar with EVM. …`
- **After:** `The core Solidity patterns—transfer(), send(), and call()—are supported on Hedera, with one important difference: the value (and msg.value) is denominated in tinybar (8 decimals) during EVM execution, not wei (18 decimals). …`

**Added — `<Warning>` after Key Considerations (new):** the `value` in `transfer`/`send`/`call` is tinybar; `_amount` in the examples is tinybar (1 HBAR = 100_000_000); passing `1 ether`/wei-scale values over-/under-transfers by 10^10.

**Example comment**
- **Before:** `// Transfer HBAR using different methods`
- **After:** `// Transfer HBAR using different methods.` + `// NOTE: _amount is in TINYBAR (8 decimals), not wei — 1 HBAR = 100_000_000.`

#### 3. `evm/development/troubleshooting.mdx` — "Decimal handling: 8 vs 18" *(was factually incorrect)*

**Paragraph**
- **Before:** `… Inside an EVM contract, msg.value, balance, and gasPrice all use 18 decimals; the relay handles the conversion. …`
- **After:** `… The JSON-RPC relay converts a transaction's value and gasPrice from 18-decimal weibar to 8-decimal tinybar before the EVM runs — so inside a contract, msg.value, address(this).balance, and the value in call/send/transfer are all tinybar (8 decimals), not wei.` + two "trap" bullets (don't assume wei; contract-to-contract not converted).

**Code example**
- **Before:**
  ```solidity
  // Inside a contract, msg.value is in 18-decimal wei (as on Ethereum).
  function deposit() external payable {
      require(msg.value >= 1 ether, "send at least 1 HBAR");   // always fails: 1 HBAR = 1e8, not 1e18
  }
  ```
- **After:**
  ```solidity
  // msg.value is TINYBAR inside the contract: 1 HBAR = 1e8, not 1 ether (1e18).
  function deposit() external payable {
      require(msg.value >= 1e8, "send at least 1 HBAR"); // 1e8 tinybar = 1 HBAR
  }
  ```
- Added a link to `/evm/differences/hbar-decimals`.

#### 4. `evm/tokens/whbar.mdx` *(grounded in `WHBAR.sol`: `deposit()` mints `msg.value` directly, `decimals = 8`)*

**Decimals bullet**
- **Before:** `WHBAR (ERC20): Uses 8 decimal places (tinybars) and ONLY for deposits (wrapping) uses 18 decimal places (weibars).`
- **After:** `WHBAR (ERC20): Uses 8 decimal places (tinybars) throughout … deposit() simply mints an amount of WHBAR equal to the msg.value it receives, and msg.value is tinybar during EVM execution. The 18-decimal weibar form is only the transaction value an off-chain caller submits; the relay converts it to tinybar before deposit() runs.`

**Deposit guidance + example**
- **Before:** "call `deposit()` and send your HBAR as `msg.value` in weibars (10^18 per HBAR)" with contract example `whbarContract.deposit{value: 10 * 10**18}();` *(= 1e19 tinybar → exceeds total HBAR supply → reverts)*
- **After:** split into two paths — **off-chain** callers send weibar (`10 * 10**18`, relay-converted); **contract-to-contract** must pass tinybar:
  ```solidity
  // Contract-to-contract `value` is TINYBAR (8 decimals): 1 HBAR = 1e8.
  function wrapTenHbar() public {
      whbarContract.deposit{value: 10 * 10**8}(); // 10 HBAR
  }
  ```

**`<Check>` "Decimal Nuance" note**
- **Before:** `Although the deposit() function requires input in 18 decimal weibars, WHBAR tokens and all related transfers and balances use 8 decimals …`
- **After:** `deposit() mints WHBAR equal to msg.value, and msg.value is tinybar (8 decimals) during execution — WHBAR is 8-decimal throughout. The 18-decimal weibar form applies only to the value an off-chain caller puts in the transaction; a contract calling deposit{value: X} must pass tinybar (1 HBAR = 1e8).`

#### 5. `evm/development/deploying.mdx` — "Impacted Variables"
- **Before:** `msg.value: The amount of HBAR sent along with the call.`
- **After:** `msg.value: The HBAR sent along with the call, in tinybar (8 decimals) — not wei. A 1 HBAR transfer is msg.value == 1e8. See Decimal Handling.`

#### 6. `evm/tutorials/intermediate/send-receive-hbar.mdx`
**Added — `<Warning>` at "Getting HBAR to the Contract" (new):** `msg.value` and the `_amount` passed to `transfer`/`send`/`call` are tinybar (1 HBAR = 100_000_000); explains why the existing `require(msg.value > 2000000000, …)` guard (~20 HBAR) is tinybar-scale; don't pass `1 ether`/wei-scale values.

---

### Preview / checks
- Renders the `<Warning>` callouts and Solidity code blocks (Mintlify; `<Warning>` is already used elsewhere in the docs).
- Internal links to `/evm/differences/hbar-decimals` resolve.
