### PR TITLE
fix: render summary-only entry when release has no bullets

### DIFF
--- a/.github/scripts/mirror-node-release-entry.js
+++ b/.github/scripts/mirror-node-release-entry.js
@@ -206,10 +206,27 @@ function main() {
     0
   );
 
-  if (totalBullets === 0) {
+  // The entry opens with the release's own summary prose, copied verbatim from
+  // the body. If the body has no preamble (e.g. a small patch release), omit it
+  // entirely — no placeholder.
+  const summary = extractSummary(body);
+
+  // No categorized bullets is not an error on its own: small patches (or a
+  // maintainer changing the changelog format) can ship a one-line summary with
+  // no "## Enhancements/Bug Fixes/..." section. Render the summary as the whole
+  // entry so the PR still opens for review. Only bail when there is genuinely
+  // nothing to render.
+  if (totalBullets === 0 && !summary) {
     throw new Error(
-      `No bullets parsed from release body for v${version}.\n` +
-        `The upstream release body format may have changed. Review manually:\n${body.slice(0, 500)}`
+      `No bullets or summary parsed from release body for v${version}.\n` +
+        `The upstream release body may be empty or in an unexpected format. Review manually:\n${body.slice(0, 500)}`
+    );
+  }
+
+  if (totalBullets === 0) {
+    console.warn(
+      `WARNING: v${version} has no categorized bullets — rendering the release summary only. ` +
+        'Verify the wording in the PR.'
     );
   }
 
@@ -229,11 +246,6 @@ function main() {
         '"### Breaking Changes" prose section above the accordions during review.'
     );
   }
-
-  // The entry opens with the release's own summary prose, copied verbatim from
-  // the body. If the body has no preamble (e.g. a small patch release), omit it
-  // entirely — no placeholder.
-  const summary = extractSummary(body);
 
   const parts = [`## [v${version}](${tagUrl})`, ''];
   if (summary) parts.push(summary, '');


### PR DESCRIPTION
## what

the mirror-node release-notes automation fails (`exit 1`) when a release body has no categorized bullets (e.g. v0.160.1 body is a single line: `Fix infinite loop in FixEvmTransactionIndexMigration (0.160) [#14011]`).

## why

`mirror-node-release-entry.js` threw "No bullets parsed from release body" whenever there were no `## Enhancements/Bug Fixes/Dependency Upgrades` bullets, treating a valid one-line patch note as a fatal error.

## fix

only error when there's genuinely nothing to render (no bullets *and* no summary). otherwise render the release summary as the entry, log a warning, and let the PR open for review. no accordions, no in-page markers.

fixes #706 
