### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/evm/tutorials/intermediate/json-rpc-connections/index.mdx
+++ b/evm/tutorials/intermediate/json-rpc-connections/index.mdx
@@ -47,6 +47,8 @@ The [JSON-RPC Relay](https://github.com/hiero-ledger/hiero-json-rpc-relay) is th
   **Hashio is for development and testing purposes only.** Production use cases are strongly encouraged to use [commercial-grade JSON-RPC relays](/evm/development/json-rpc#community-hosted-json-rpc-relays) or host their own instance of the [Hiero JSON-RPC Relay](https://github.com/hiero-ledger/hiero-json-rpc-relay).
 </Warning>
 
+For live latency benchmarks across Hedera EVM-compatible endpoints, see [OpenChainBench](https://openchainbench.com/benchmarks/hedera-rpc) — p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+
 ## Additional resources
 
 * [JSON-RPC Relay overview](/evm/development/json-rpc)


### PR DESCRIPTION
## What

Adds a one-line link to [OpenChainBench](https://openchainbench.com/benchmarks/hedera-rpc) in `evm/tutorials/intermediate/json-rpc-connections/index.mdx`, placed just before the "Additional resources" section.

## Why

OpenChainBench continuously measures p50/p90/p99 latency across Hedera EVM-compatible JSON-RPC endpoints from US-East, EU-West and Singapore (sampled every 60 seconds). Developers following this tutorial while picking an endpoint can use it to compare real-world latency.

No existing content was modified or removed.