### PR TITLE
docs: add EVM overview pages and glossary cross-links (#612 #735)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2295,7 +2295,10 @@
           {
             "group": "Overview",
             "pages": [
-              "evm/index"
+              "evm/index",
+              "evm/overview/evm-on-hedera-explained",
+              "evm/overview/why-hedera-for-evm",
+              "evm/overview/choose-your-path"
             ]
           },
           {

--- a/evm/index.mdx
+++ b/evm/index.mdx
@@ -84,6 +84,50 @@ mode: wide
   </div>
 </div>
 
+{/* ── UNDERSTAND THE EVM ON HEDERA ─────────────────────────────────────── */}
+<div className="landing-section">
+  <h2 id="understand-the-evm-on-hedera" className="landing-section-heading" style={{ marginBottom: '24px' }}>
+    <a href="#understand-the-evm-on-hedera">Understand the EVM on Hedera</a>
+  </h2>
+  <p className="landing-section-description">
+    Deploy Solidity contracts with the tools you already know. What changes is the settlement layer underneath: Hashgraph consensus gives you fast absolute finality, fees fixed in USD, and native token and consensus services you can call from your contracts.
+  </p>
+
+  <div className="landing-grid">
+
+    <a href="/evm/overview/evm-on-hedera-explained" className="landing-card">
+      <div className="landing-card-icon">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </div>
+      <div>
+        <div className="landing-card-title">EVM on Hedera Explained</div>
+        <div className="landing-card-desc">Besu execution, consensus and finality, the account model, and gas.</div>
+      </div>
+    </a>
+
+    <a href="/evm/overview/why-hedera-for-evm" className="landing-card">
+      <div className="landing-card-icon">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+      </div>
+      <div>
+        <div className="landing-card-title">Why Hedera for EVM Developers</div>
+        <div className="landing-card-desc">Fixed low fees, fast finality, and native services from Solidity.</div>
+      </div>
+    </a>
+
+    <a href="/evm/overview/choose-your-path" className="landing-card">
+      <div className="landing-card-icon">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg>
+      </div>
+      <div>
+        <div className="landing-card-title">Choose Your Path</div>
+        <div className="landing-card-desc">A decision guide by experience level, from new to EVM to Hedera-native.</div>
+      </div>
+    </a>
+
+  </div>
+</div>
+
 {/* ── HEDERA-NATIVE FEATURES ──────────────────────────────────────────── */}
 <div className="landing-section">
   <h2 id="hedera-native-features" className="landing-section-heading">

--- a/evm/overview/choose-your-path.mdx
+++ b/evm/overview/choose-your-path.mdx
@@ -1,0 +1,77 @@
+---
+title: "Choose Your Path"
+description: "A short decision guide for building on the EVM on Hedera, by experience level."
+---
+
+Everyone building here uses the same [EVM](/support/glossary#ethereum-virtual-machine-evm) and the same tools. Where you start depends on what you already know. Pick the profile that fits you best.
+
+<CardGroup cols={3}>
+  <Card title="New to EVM development" icon="seedling" href="#new-to-evm-development" />
+  <Card title="Migrating from Ethereum" icon="right-left" href="#migrating-from-ethereum-or-another-evm-chain" />
+  <Card title="Hedera-native developer" icon="cubes" href="#hedera-native-developer-adding-the-evm" />
+</CardGroup>
+
+## New to EVM development
+
+You are new to Solidity and smart contracts, or new to web3 entirely. Start with the tooling and deploy a working contract before going deeper.
+
+<Steps>
+  <Step title="Set up a wallet and testnet account">
+    Add Hedera Testnet to MetaMask and fund an account from the faucet.
+    [Set Up MetaMask](/evm/quickstart/setup-metamask) and [Get Test HBAR](/evm/quickstart/get-test-hbar).
+  </Step>
+  <Step title="Deploy your first contract">
+    Deploy a Solidity contract with Hardhat and the JSON-RPC relay.
+    [Deploy with Hardhat](/evm/quickstart/deploy-with-hardhat).
+  </Step>
+  <Step title="Understand what makes Hedera different">
+    Read how execution, finality, and the account model work.
+    [EVM on Hedera Explained](/evm/overview/evm-on-hedera-explained).
+  </Step>
+</Steps>
+
+## Migrating from Ethereum or another EVM chain
+
+You know [Solidity](/support/glossary#solidity), Hardhat, Foundry, or Remix and want to bring existing contracts to Hedera. Your bytecode and tooling carry over. Focus on the handful of behaviors that differ.
+
+<Steps>
+  <Step title="Review the differences">
+    Start with the differences catalogue, then the two that trip people up most: HBAR decimal precision and the account and key model.
+    [EVM Differences](/evm/differences/index), [HBAR Decimals](/evm/differences/hbar-decimals), and [Accounts and Keys](/evm/differences/accounts-and-keys).
+  </Step>
+  <Step title="Point your tools at Hedera">
+    Configure Hardhat or Foundry against the JSON-RPC relay.
+    [JSON-RPC Relay](/evm/development/json-rpc/index) and [Tools](/evm/tools/index).
+  </Step>
+  <Step title="Deploy and verify">
+    Deploy your contract and verify the source.
+    [Deploying](/evm/development/deploying) and [Verifying](/evm/development/verifying).
+  </Step>
+</Steps>
+
+<Tip>
+  Before porting scripts that move value, read [HBAR Decimals](/evm/differences/hbar-decimals). [HBAR](/support/glossary#hbar) is 8 decimals natively but the relay presents 18-decimal units to EVM tools, which is the most common migration surprise.
+</Tip>
+
+## Hedera-native developer adding the EVM
+
+You already build with the Hiero SDKs and Hedera services, and you want to add Solidity contracts or call your existing HTS tokens from contract code.
+
+<Steps>
+  <Step title="See how native services map into the EVM">
+    Learn how to reach [HTS](/support/glossary#hedera-token-service-hts), [HCS](/support/glossary#hedera-consensus-service-hcs), and other services from Solidity through [system contracts](/support/glossary#system-smart-contracts).
+    [System Contracts](/evm/hedera-services/system-contracts/index) and [HTS from Solidity](/evm/hedera-services/system-contracts/hts).
+  </Step>
+  <Step title="Learn the EVM account model">
+    See how Hedera accounts map to EVM addresses.
+    [EVM on Hedera Explained](/evm/overview/evm-on-hedera-explained) and [Accounts](/evm/development/accounts).
+  </Step>
+  <Step title="Combine ERC and HTS">
+    Use hybrid tokenization to keep ERC compatibility with native controls.
+    [Hybrid Tokenization](/evm/hedera-services/hybrid/index).
+  </Step>
+</Steps>
+
+## Not sure yet?
+
+If you are deciding between the EVM and the native SDKs at the network level, start with [Choose Your Path](/learn/getting-started/choose-your-path) in Getting Started, which compares the EVM and native SDK approaches across all of Hedera.

--- a/evm/overview/evm-on-hedera-explained.mdx
+++ b/evm/overview/evm-on-hedera-explained.mdx
@@ -1,0 +1,83 @@
+---
+title: "EVM on Hedera Explained"
+description: "How the EVM runs on Hedera: Besu-based execution, consensus and settlement, the account model, gas, and finality."
+---
+
+Hedera runs the same [Ethereum Virtual Machine](/support/glossary#ethereum-virtual-machine-evm) you already target, so your [Solidity](/support/glossary#solidity) bytecode, ABIs, and tooling work without modification. The difference is what sits underneath the EVM: instead of ordering transactions into blocks chosen by a block producer, Hedera settles them with Hashgraph consensus, a [proof-of-stake](/support/glossary#proof-of-stake-pos) aBFT algorithm. This page explains how execution, consensus, accounts, gas, and finality fit together.
+
+## Besu-based execution
+
+Hedera's smart contract service embeds [Hyperledger Besu](/support/glossary#hyperledger-besu-evm), the same EVM implementation used across the Ethereum ecosystem, as its execution layer. Contracts compile to standard EVM bytecode, and opcodes behave as they do on Ethereum. Hedera tracks Ethereum's hard forks; for the current Besu version and the exact supported hard fork, see [Deploying](/evm/development/deploying), which is the source of truth for that detail.
+
+Because execution is standard Besu:
+
+- Solidity and [Vyper](/support/glossary#vyper) contracts deploy unchanged.
+- Existing ABIs, libraries, and audited contract patterns carry over.
+- EVM tools talk to Hedera through the [JSON-RPC relay](/evm/development/json-rpc/index), which translates standard Ethereum JSON-RPC calls into Hedera transactions and queries.
+
+A small number of behaviors differ from L1 Ethereum. Those are catalogued in [EVM Differences](/evm/differences/index).
+
+## Consensus and settlement
+
+On most EVM chains, one layer both orders transactions and executes them, and a block producer decides ordering. On Hedera these responsibilities are separate:
+
+1. **Consensus** - Consensus nodes run the Hashgraph algorithm to agree on the order and timestamp of every transaction. This is [aBFT](/support/glossary#asynchronous-byzantine-fault-tolerance-abft) (asynchronous Byzantine fault tolerant) and produces a fair, deterministic order with no block producer choosing what goes where.
+2. **Settlement and execution** - Once order is fixed, each node executes the transaction against network state. Smart contract calls run in Besu at this stage, and the resulting state changes are applied identically on every node.
+
+There are no blocks competing to be canonical and no reorganizations. The consensus timestamp assigned to a transaction is final the moment consensus is reached. To learn how Hashgraph reaches agreement, see [Hashgraph Consensus](/learn/core-concepts/hashgraph/index).
+
+## The account model
+
+Every actor on Hedera is a Hedera account with an ID in the form `0.0.<num>` (for example, `0.0.1234`). EVM tooling expects a 20-byte hex address, so each account also has an [EVM address](/support/glossary#evm-address). There are two ways an account gets one:
+
+| EVM address type | How it is derived | When you get it |
+| --- | --- | --- |
+| **EVM Address from Public Key** | Last 20 bytes of the Keccak-256 hash of the account's [ECDSA](/support/glossary#ecdsa-secp256k1) public key | Set at creation for accounts made with an ECDSA key; matches the address MetaMask and other EVM wallets expect |
+| **EVM Address from Account ID** | The account number encoded as a 20-byte value (a "long-zero" address such as `0x00...04d2`) | Available for any account, including those created with an [ED25519](/support/glossary#ed25519) key |
+
+For EVM-oriented applications, create accounts with an ECDSA key and set the **EVM Address from Public Key** at creation. This gives native compatibility with EVM wallets, JSON-RPC tooling, and smart contract interactions.
+
+<Tip>
+  The EVM Address from Public Key is immutable. Rotating keys with `CryptoUpdateTransaction` does not change it; the address stays bound to the original ECDSA public key. If keys are compromised or must be replaced, create a new ECDSA account with a new EVM address and migrate assets and state rather than relying on key rotation to preserve the same EVM identity.
+</Tip>
+
+When a contract or tool references an address that has never transacted, Hedera can create the account automatically the first time value arrives. This table is a summary; for the full account and address model see [Accounts](/evm/development/accounts), and for how it differs from Ethereum see [Accounts and Keys](/evm/differences/accounts-and-keys). The native-account view is in [Auto Account Creation](/learn/core-concepts/accounts/auto-account-creation).
+
+## Gas and fees
+
+Contract execution is metered in [gas](/support/glossary#gas-fee), exactly as on Ethereum, so gas estimation and `gasLimit` work the way your tools expect. Two things differ:
+
+- **Pricing is in USD, paid in [HBAR](/support/glossary#hbar)** - The network prices gas against a USD target and converts to HBAR at the current exchange rate, rather than through a fee market auction. Costs stay predictable under load.
+- **HBAR uses different decimal precision than ETH** - HBAR has 8 decimals natively, but the JSON-RPC relay presents balances and values to EVM tools in 18-decimal `wei`-style units. This conversion is the most common source of surprise when porting scripts. See [HBAR Decimals](/evm/differences/hbar-decimals).
+
+For a full breakdown of contract costs, including gas and state storage, see [Gas and Fees](/evm/development/gas-fees) and [State Rent](/evm/development/rent).
+
+## Finality
+
+Hedera [finality](/support/glossary#finality) is absolute, not probabilistic. Once a transaction receives its consensus timestamp, it is final and cannot be reorganized out of history. There is no confirmation count to wait for.
+
+| | Hedera | L1 Ethereum | Typical optimistic L2 |
+| --- | --- | --- | --- |
+| **Finality type** | Absolute (aBFT) | Probabilistic | Inherits L1, plus challenge window |
+| **Time to finality** | 3 to 5 seconds | ~13 minutes (after enough confirmations) | Minutes for soft confirmation, up to ~7 days for L1 withdrawal finality |
+| **Reorgs** | None | Possible near the head | Depends on sequencer and L1 |
+| **Settlement layer** | Hashgraph consensus | Ethereum L1 | Rollup settling to Ethereum L1 |
+
+Because finality is reached in seconds and never reverses, application logic that would normally wait for N confirmations can act on a transaction as soon as it has a consensus timestamp.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Why Hedera for EVM Developers" icon="star" href="/evm/overview/why-hedera-for-evm">
+    The value proposition compared to other EVM chains.
+  </Card>
+  <Card title="EVM Differences" icon="list-check" href="/evm/differences/index">
+    Every behavior that differs from L1 Ethereum, in detail.
+  </Card>
+  <Card title="Smart Contracts on Hedera" icon="file-contract" href="/learn/core-concepts/services/smart-contracts">
+    The core-concepts view of the smart contract service.
+  </Card>
+  <Card title="Quickstart" icon="rocket" href="/evm/quickstart/setup-metamask">
+    Deploy your first contract on testnet.
+  </Card>
+</CardGroup>

--- a/evm/overview/why-hedera-for-evm.mdx
+++ b/evm/overview/why-hedera-for-evm.mdx
@@ -1,0 +1,63 @@
+---
+title: "Why Hedera for EVM Developers?"
+description: "Fixed low fees, fast absolute finality, predictable gas, and native token and consensus services you can call from Solidity."
+---
+
+If you already build on the [EVM](/support/glossary#ethereum-virtual-machine-evm), Hedera lets you keep your contracts, wallets, and tooling while removing the parts of L1 and L2 development that are hard to plan around: fee spikes, slow [finality](/support/glossary#finality), and [gas](/support/glossary#gas-fee) that swings with demand. You also get direct access to Hedera's native services from [Solidity](/support/glossary#solidity), which is not available on general-purpose EVM chains.
+
+## Fixed, low fees
+
+Hedera prices transactions in USD and charges the equivalent in [HBAR](/support/glossary#hbar) at the current exchange rate. There is no fee market auction, so costs do not climb when the network is busy.
+
+- Simple transactions such as an HBAR transfer cost about $0.0001. Smart contract calls are metered in gas but stay low and predictable (see [Gas and Fees](/evm/development/gas-fees)).
+- Fees are published in the [fee schedule](/networks/fees) and change infrequently.
+- No priority-fee bidding to get included.
+
+This makes high-volume applications, where per-transaction gas would be prohibitive elsewhere, practical to run.
+
+## Fast absolute finality
+
+Hashgraph consensus gives 3 to 5 second absolute finality. Once a transaction has a consensus timestamp it is final and cannot be reorganized. There is no confirmation count to wait for and no reorg risk near the chain head, so your application can act on a result as soon as it settles. See [EVM on Hedera Explained](/evm/overview/evm-on-hedera-explained) for how consensus and settlement produce this.
+
+## Predictable gas
+
+Contract execution is metered in gas just like Ethereum, so `gasLimit`, estimation, and your existing scripts work as expected. Because gas is priced against a USD target rather than an auction, the cost of a given contract call stays stable across network conditions. Details are in [Gas and Fees](/evm/development/gas-fees).
+
+## Native services from Solidity
+
+This is the capability EVM chains do not have. Through [system contracts](/support/glossary#system-smart-contracts) at fixed addresses, your Solidity code can call Hedera's native services directly:
+
+- **[Hedera Token Service (HTS)](/support/glossary#hedera-token-service-hts)** - Create, mint, transfer, burn, and manage tokens with native controls such as [KYC](/support/glossary#know-your-customer-kyc), freeze, pause, and wipe, without writing token accounting yourself. See the [HTS system contract](/evm/hedera-services/system-contracts/hts).
+- **[Hedera Consensus Service (HCS)](/support/glossary#hedera-consensus-service-hcs)** - Publish verifiable, ordered messages for audit trails and event streams.
+- **Schedule and account services** - Coordinate multi-party transactions and query account state from contracts. See [System Contracts](/evm/hedera-services/system-contracts/index).
+
+You can also combine ERC standards with HTS in a single token through [hybrid tokenization](/evm/hedera-services/hybrid/index), keeping ERC-20 or ERC-721 compatibility while gaining native compliance controls.
+
+## How Hedera compares
+
+This is the value-proposition cut for EVM developers weighing chains. For the complete Hedera vs Ethereum comparison, including governance, network state, and key management, see [EVM Differences](/evm/differences/index).
+
+| | Hedera | L1 Ethereum | Typical EVM L2 |
+| --- | --- | --- | --- |
+| **Finality type** | Absolute ([aBFT](/support/glossary#asynchronous-byzantine-fault-tolerance-abft)) | Probabilistic | Inherits L1 |
+| **Fee model** | Fixed in USD, no auction | Gas auction | Variable with L1 and sequencer |
+| **Native token service (HTS)** | Yes, from Solidity | No | No |
+| **Native consensus and messaging (HCS)** | Yes | No | No |
+| **Tooling** | MetaMask, Hardhat, Foundry, Ethers.js | Same | Same |
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Choose Your Path" icon="signs-post" href="/evm/overview/choose-your-path">
+    Pick a starting point based on your background.
+  </Card>
+  <Card title="EVM Differences" icon="list-check" href="/evm/differences/index">
+    What changes when you move contracts to Hedera.
+  </Card>
+  <Card title="HTS from Solidity" icon="coins" href="/evm/hedera-services/system-contracts/hts">
+    Call the native token service from your contracts.
+  </Card>
+  <Card title="Quickstart" icon="rocket" href="/evm/quickstart/setup-metamask">
+    Deploy your first contract on testnet.
+  </Card>
+</CardGroup>

--- a/support/glossary.mdx
+++ b/support/glossary.mdx
@@ -5,9 +5,11 @@ description: "Glossary of Hedera and Web3 terms for developers: account ID, alia
 
 This glossary intends to provide a reference for Hedera and general web3 key terms. The purpose is to assist developers, particularly those new to the field or non-specialists, in understanding essential definitions related to various aspects of this technology. It covers basic to complex concepts and essential development tools and is an accessible resource for developers.
 
-## [#](#undefined) [A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) [G](#g) [H](#h) [I](#i) [J](#j) [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) [P](#p) [Q](#q) [R](#r) [S](#s) [T](#t) [U](#v) [V](#v) [W](#w) [X](#z) [Y](#z) [Z](#z)
+**Jump to:** [#](#symbols) · [A](#a) · [B](#b) · [C](#c) · [D](#d) · [E](#e) · [F](#f) · [G](#g) · [H](#h) · [I](#i) · [J](#j) · [K](#k) · [L](#l) · [M](#m) · [N](#n) · [O](#o) · [P](#p) · [Q](#q) · [R](#r) · [S](#s) · [T](#t) · [U](#u) · [V](#v) · [W](#w) · X · Y · [Z](#z)
 
 ---
+
+<a id="symbols" />
 
 ## \#
 
@@ -193,8 +195,6 @@ Another term for a [blockchain](#blockchain).
 
 ---
 
----
-
 A unique identifier for a specific chain within a network. In networks that support multiple chains or side chains, the chain ID helps distinguish between different chains.
 
 ### Client
@@ -239,7 +239,7 @@ A type of digital or virtual currency used for payment transactions. Unlike [fia
 
 A platform, application, or website that rewards users in cryptocurrency when they complete certain tasks. Rewards tend to be in tiny increments of cryptocurrency. Rewardable tasks can include browser mining, playing games, watching videos, completing surveys, referring new users, etc.
 
-### Cryptography/Cryptographic
+### Cryptography
 
 ---
 
@@ -681,13 +681,13 @@ This service provides the ability to issue and manage tokens on the Hedera Netwo
 
 ---
 
-A [cryptocurrency wallet](#cryptocurrency-wallet) that is _always_ connected to the internet and can be either a mobile application, web application, or browser extension. As they are always connected to the Internet, hot wallets are not as secure as [cold wallets](#cold-wallet), which are only connected to the Internet during transactions.
+A [cryptocurrency wallet](#crypto-wallet) that is _always_ connected to the internet and can be either a mobile application, web application, or browser extension. As they are always connected to the Internet, hot wallets are not as secure as [cold wallets](#cold-wallet), which are only connected to the Internet during transactions.
 
 ### Hyperledger Besu EVM
 
 ---
 
-An open-source [Ethereum](#ethereum) client developed under the Hyperledger project and a virtual machine that replaced the EthereumJ virtual machine in the [Consensus Node release 0.19](https://github.com/hashgraph/hedera-services/releases/tag/v0.19.1) as a result of [HIP-26](https://hips.hedera.com/hip/hip-26). This migration enables Hedera to maintain parity with Ethereum Mainnet evolutions, such as the EVM container formats, new opcodes, and precompiled contracts. The Besu integration is configured to use the [“London” hard fork](https://ethereum.org/en/history/#london) of Ethereum Mainnet.
+An open-source [Ethereum](#ethereum) client developed under the Hyperledger project and a virtual machine that replaced the EthereumJ virtual machine in the [Consensus Node release 0.19](https://github.com/hashgraph/hedera-services/releases/tag/v0.19.1) as a result of [HIP-26](https://hips.hedera.com/hip/hip-26). This migration enables Hedera to maintain parity with Ethereum Mainnet evolutions, such as the EVM container formats, new opcodes, and precompiled contracts. The Besu integration tracks Ethereum Mainnet hard forks; as of Hedera Mainnet release [0.50.0](/networks/release-notes/services#v0.50), it supports the [Cancun hard fork](https://ethereum.org/en/history/#cancun) of Ethereum Mainnet, with some modifications. For the exact supported hard fork in the current release, see [Deploying](/evm/development/deploying).
 
 ## I
 
@@ -845,7 +845,7 @@ The unique ID of a non-fungible token composed of the token ID and serial number
 
 ---
 
-A [cryptographic](#cryptography) nonce is an arbitrary, single-use, whole, binary number used for communication in security functions. The acronym “nonce” is an abbreviation of "number only used once." A basic nonce in [Bitcoin](#bitcoin) is 32-bit (4-byte). A strong nonce has at least 128 bits of entropy. Solving the hash on a block is how a miner finds the nonce.
+A [cryptographic](#cryptography) nonce is an arbitrary, single-use, whole, binary number used for communication in security functions. The acronym “nonce” is an abbreviation of "number only used once." A basic nonce in [Bitcoin](#bitcoin-btc) is 32-bit (4-byte). A strong nonce has at least 128 bits of entropy. Solving the hash on a block is how a miner finds the nonce.
 
 Uses for a nonce: authentication, initialization vectors, hashing, indexing, smart contracts, and block validation.
 
@@ -1245,6 +1245,8 @@ Trustless is a term associated with distributed ledger technology such as [block
 ### Turing Complete
 
 Turing complete means a system or a language has the ability to simulate any computer algorithm, no matter how complex. It's like saying if you give this system enough time and memory, it can run any program a computer can execute, whether it's a simple calculator or a complex video game. The importance of Turing completeness as it pertains to distributed ledger technology is that it allows for the programmatic development of smart contracts.
+
+## U
 
 ### Universally Unique Identifier (UUID)
 


### PR DESCRIPTION
## summary

builds out the evm overview section (epic #612) and cleans up the glossary (#735).

### evm overview (#612)
- new pages: `evm-on-hedera-explained`, `why-hedera-for-evm`, `choose-your-path`
- `evm/index` landing routes into the three explainers (resolves #569 without a competing landing)
- wired into the evm tab nav in `docs.json`
- fact-checked against primary sources (hedera.com, hips, hiero-consensus-node); comparison tables trimmed to teasers that defer to `evm/differences`; glossary cross-links added throughout

### glossary (#735)
- added an a–z jump bar at the top
- fixed broken letter anchors (`#`, `u`, `x`, `y`) and added a proper `## u` section
- corrected 3 pre-existing dead cross-references (`#crypto-wallet`, `#bitcoin-btc`, `#cryptography`)
- renamed `cryptography/cryptographic` → `cryptography`; updated the besu entry (london → cancun)

## validation
- all internal links and glossary anchors verified resolving
- `mint broken-links` clean for all touched files

closes #569, #570, #571, #572, #735 
