### PR TITLE
docs: add MirrorNodeAccountBalanceQuery java/go tabs and align native quickstart SDK usage

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2167,6 +2167,7 @@
               "learn/getting-started/what-is-hedera",
               "learn/getting-started/why-hedera",
               "learn/getting-started/choose-your-path",
+              "learn/getting-started/create-portal-account",
               "learn/getting-started/testnet-faucet",
               "learn/getting-started/faucet-api",
               "learn/getting-started/portal-playground",
@@ -2529,7 +2530,6 @@
           {
             "group": "Quickstart",
             "pages": [
-              "learn/getting-started/create-portal-account",
               "native/quickstart/javascript",
               "native/quickstart/java",
               "native/quickstart/go"

--- a/learn/getting-started/create-portal-account.mdx
+++ b/learn/getting-started/create-portal-account.mdx
@@ -480,7 +480,7 @@ fmt.Printf("EVM Address: 0x%s\n", newPublicKey.ToEvmAddress())
 # Build & execute the account creation transaction
 transaction = (
     AccountCreateTransaction()
-      .set_key_with_alias(newPublicKey) # set the account key and EVM address alias
+      .set_key_with_alias(newPublicKey) # set the account key and its EVM Address from Public Key
       .set_initial_balance(Hbar(20))    # fund with 20 HBAR
 )
 
@@ -884,7 +884,7 @@ newPublicKey = newPrivateKey.public_key()
 # build & execute the account creation transaction
 transaction = (
     AccountCreateTransaction()
-      .set_key_with_alias(newPublicKey) # set the account key and EVM address alias
+      .set_key_with_alias(newPublicKey) # set the account key and its EVM Address from Public Key
       .set_initial_balance(Hbar(20))    # fund with 20 HBAR
 )
 receipt = transaction.execute(client)

--- a/learn/getting-started/create-portal-account.mdx
+++ b/learn/getting-started/create-portal-account.mdx
@@ -1,14 +1,69 @@
 ---
 title: "Create an Account"
+icon: "user"
 ---
 
-Learn how to create a new Hedera **account** on _testnet_ using the JavaScript, Java, Go, SDK, or Python. A [`Hedera account`](/learn/core-concepts/accounts) is your identity on‑chain. It holds your HBAR (the network’s currency) and lets you sign transactions.
+Learn how to create a new Hedera **account** on _testnet_ using the JavaScript, Java, Go, or Python SDK. A [`Hedera account`](/learn/core-concepts/accounts) is your identity on‑chain. It holds your HBAR (the network’s currency) and lets you sign transactions.
+
+---
+
+## Get a testnet account from the portal
+
+Before writing any code, get a funded testnet account and its keys from the developer portal. You can also submit your first transaction straight from the browser-based playground, with no setup.
+
+<Steps>
+<Step title="Open the playground">
+
+<Card
+  horizontal
+  title="OPEN PLAYGROUND"
+  href="https://portal.hedera.com/playground"
+  icon="rectangle-terminal"
+/>
+</Step>
+
+<Step title="Submit a Transfer HBAR transaction">
+
+Under **Account & HBAR**, select **Transfer HBAR** from the left navigation.
+
+1. Replace `receiverAccount` with account ID `0.0.800`.
+2. Then click **Get Account Balance** under Queries.
+
+Click **Execute** to submit your first transaction.
+
+<Frame>
+  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-1.png" />
+</Frame>
+</Step>
+
+<Step title="Create your testnet account">
+
+When you click **Execute**, you are prompted to sign up for a developer portal account. Once logged in, click **CREATE ACCOUNT** to complete the testnet account creation flow. Your new account is automatically funded with **1000 HBAR**.
+
+<div><Frame>
+  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-2.png" />
+</Frame> <Frame>
+  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-3.png" />
+</Frame> <Frame>
+  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-4.png" />
+</Frame></div>
+</Step>
+
+<Step title="Copy your account ID and key">
+
+View your account ID and ECDSA key pair from the portal dashboard. Use the **account ID** as your `OPERATOR_ID` and the **DER Encoded Private Key** (starts with `303...`) as your `OPERATOR_KEY` in the steps below.
+
+<Frame>
+  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-5.png" />
+</Frame>
+</Step>
+</Steps>
 
 ---
 
 ## Prerequisites
 
-- A Hedera testnet **operator account ID** and **ECDSA** **DER-encoded private key** (from the [Quickstart](/native/quickstart/javascript)).
+- A Hedera testnet **operator account ID** and **ECDSA** **DER-encoded private key** (from the [portal](#get-a-testnet-account-from-the-portal) above).
 - A small amount of testnet **HBAR (ℏ)** to pay the `$0.05` account‑creation fee.
 
 <Note>
@@ -39,7 +94,7 @@ npm init -y
 Ensure you have [**Node.js**](https://nodejs.org/en/download) `v18` or later installed on your machine. Then, install the[ JavaScript SDK](https://github.com/hiero-ledger/hiero-sdk-js).
 
 ```bash
-npm install --save @hashgraph/sdk
+npm install --save @hiero-ledger/sdk
 ```
 
 Update your `package.json` file to enable ES6 modules and configure the project:
@@ -57,7 +112,7 @@ Update your `package.json` file to enable ES6 modules and configure the project:
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hashgraph/sdk": "^2.69.0"
+    "@hiero-ledger/sdk": "^2.87.0"
   }
 }
 ```
@@ -70,7 +125,7 @@ import {
   PrivateKey,
   AccountCreateTransaction,
   Hbar,
-} from "@hashgraph/sdk";
+} from "@hiero-ledger/sdk";
 ```
 
 </Tab>
@@ -85,17 +140,17 @@ Create a new **Maven** project and name it `HederaExamples`. Add the following d
     <dependency>
         <groupId>com.hedera.hashgraph</groupId>
         <artifactId>sdk</artifactId>
-        <version>2.61.0</version>
+        <version>2.77.0</version>
     </dependency>
     <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.10.1</version>
+        <version>2.14.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
-        <version>1.73.0</version>
+        <version>1.83.1</version>
     </dependency>
 </dependencies>
 ```
@@ -113,9 +168,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.hedera.hashgraph:sdk:2.60.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'io.grpc:grpc-netty-shaded:1.61.0'
+    implementation 'com.hedera.hashgraph:sdk:2.77.0'
+    implementation 'com.google.code.gson:gson:2.14.0'
+    implementation 'io.grpc:grpc-netty-shaded:1.83.1'
 }
 
 application {
@@ -157,22 +212,17 @@ import (
     "os"
     "time"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 )
 ```
 
 In your project's root directory, initialize modules and pull in the [Go SDK](https://github.com/hiero-ledger/hiero-sdk-go):
-
-```wrap
-
-```
 
 ```go-module
 go mod init create_account_demo
 go get github.com/hiero-ledger/hiero-sdk-go/v2@latest
 go mod tidy
 ```
-
 </Tab>
 
 <Tab title="Python">
@@ -270,7 +320,7 @@ Set your testnet operator credentials as environment variables. Your `OPERATOR_I
 
 ```bash
 export OPERATOR_ID="0.0.1234"
-export OPERATOR_KEY="3030020100300506032b657004220420..."
+export OPERATOR_KEY="3030020100300706052b8104000a04220420..."
 ```
 
 ---
@@ -294,7 +344,7 @@ const client = Client.forTestnet()
 ```java Java
 // Load your operator credentials
 AccountId operatorId = AccountId.fromString(System.getenv("OPERATOR_ID"));
-PrivateKey operatorKey = PrivateKey.fromString(System.getenv("OPERATOR_KEY"));
+PrivateKey operatorKey = PrivateKey.fromStringECDSA(System.getenv("OPERATOR_KEY"));
 
 // Initialize your testnet client and set operator
 Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
@@ -302,11 +352,11 @@ Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
 
 ```go Go highlight={1}
 // load your operator credentials
-operatorId, _ := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
-operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+operatorId, _ := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+operatorKey, _ := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
 
 // initialize the client for testnet
-client := hedera.ClientForTestnet()
+client := hiero.ClientForTestnet()
 client.SetOperator(operatorId, operatorKey)
 
 ```
@@ -314,7 +364,7 @@ client.SetOperator(operatorId, operatorKey)
 ```python Python
 # Load your operator credentials
 operatorId = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-operatorKey = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+operatorKey = PrivateKey.from_string_der(os.getenv("OPERATOR_KEY", ""))
 
 # Initialize your testnet client and set operator
 client = Client()
@@ -348,7 +398,7 @@ PublicKey newPublicKey   = newPrivateKey.getPublicKey();
 
 ```go Go
 // generate a new key pair
-newPrivateKey, _ := hedera.PrivateKeyGenerateEcdsa()
+newPrivateKey, _ := hiero.PrivateKeyGenerateEcdsa()
 newPublicKey := newPrivateKey.PublicKey()
 ```
 
@@ -404,9 +454,9 @@ System.out.println("EVM Address: 0x" + newPublicKey.toEvmAddress());
 
 ```go Go
 // build & execute the account creation transaction
-transaction := hedera.NewAccountCreateTransaction().
+transaction := hiero.NewAccountCreateTransaction().
     SetECDSAKeyWithAlias(newPublicKey).     // set the account key
-    SetInitialBalance(hedera.NewHbar(20))   // fund with 20 HBAR
+    SetInitialBalance(hiero.NewHbar(20))   // fund with 20 HBAR
 
 // execute the transaction and get response
 txResponse, err := transaction.Execute(client)
@@ -430,7 +480,7 @@ fmt.Printf("EVM Address: 0x%s\n", newPublicKey.ToEvmAddress())
 # Build & execute the account creation transaction
 transaction = (
     AccountCreateTransaction()
-      .set_key(newPublicKey)            # set the account key
+      .set_key_with_alias(newPublicKey) # set the account key and EVM address alias
       .set_initial_balance(Hbar(20))    # fund with 20 HBAR
 )
 
@@ -607,7 +657,7 @@ import {
   PrivateKey,
   AccountCreateTransaction,
   Hbar
-} from "@hashgraph/sdk";
+} from "@hiero-ledger/sdk";
 
 async function createAccountDemo() {
 // load your operator credentials
@@ -681,7 +731,7 @@ public class CreateAccountDemo {
 
         // initialize the client for testnet
         Client client = Client.forTestnet()
-            .setOperator(AccountId.fromString(operatorId),         PrivateKey.fromString(operatorKey));
+            .setOperator(AccountId.fromString(operatorId),         PrivateKey.fromStringECDSA(operatorKey));
 
         // generate a new key pair
         PrivateKey newPrivateKey = PrivateKey.generateECDSA();
@@ -746,27 +796,27 @@ import (
 	"os"
 	"time"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 
 )
 
 func main() {
 // load your operator credentials
-operatorId, _ := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
-operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+operatorId, _ := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+operatorKey, _ := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
 
     // initialize the client for testnet
-    client := hedera.ClientForTestnet()
+    client := hiero.ClientForTestnet()
     client.SetOperator(operatorId, operatorKey)
 
     // generate a new key pair
-    newPrivateKey, _ := hedera.PrivateKeyGenerateEcdsa()
+    newPrivateKey, _ := hiero.PrivateKeyGenerateEcdsa()
     newPublicKey := newPrivateKey.PublicKey()
 
     // build & execute the account creation transaction
-    transaction := hedera.NewAccountCreateTransaction().
+    transaction := hiero.NewAccountCreateTransaction().
     	SetECDSAKeyWithAlias(newPublicKey).   // set the account key with alias
-    	SetInitialBalance(hedera.NewHbar(20)) // fund with 20 HBAR
+    	SetInitialBalance(hiero.NewHbar(20)) // fund with 20 HBAR
 
     txResponse, _ := transaction.Execute(client)
     receipt, _ := txResponse.GetReceipt(client)
@@ -821,7 +871,7 @@ from hiero_sdk_python.utils.crypto_utils import keccak256
 
 # load your operator credentials
 operatorId = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-operatorKey = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+operatorKey = PrivateKey.from_string_der(os.getenv("OPERATOR_KEY", ""))
 
 # initialize the client for testnet
 client = Client()
@@ -834,7 +884,7 @@ newPublicKey = newPrivateKey.public_key()
 # build & execute the account creation transaction
 transaction = (
     AccountCreateTransaction()
-      .set_key(newPublicKey)            # set the account key
+      .set_key_with_alias(newPublicKey) # set the account key and EVM address alias
       .set_initial_balance(Hbar(20))    # fund with 20 HBAR
 )
 receipt = transaction.execute(client)
@@ -876,7 +926,7 @@ Ensure your environment variables are set:
 
 ```bash
 export OPERATOR_ID="0.0.1234"
-export OPERATOR_KEY="3030020100300506032b657004220420..."
+export OPERATOR_KEY="3030020100300706052b8104000a04220420..."
 ```
 
 <Tabs>
@@ -941,75 +991,15 @@ Account balance: 20 ℏ
 ### ‼️ Troubleshooting
 
 <Accordion title="Common ERROR messages and solutions ⬇️">
-  <table>
-    <thead>
-      <tr>
-        <th>Error message</th>
-        <th>Likely cause</th>
-        <th>Fix</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <code>INSUFFICIENT_PAYER_BALANCE</code>
-        </td>
-        <td>Operator account lacks enough ℏ for the fee.</td>
-        <td>
-          Top‑up your testnet account with the{" "}
-          <a href="https://portal.hedera.com/signup">HBAR faucet</a>.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <code>INVALID_SIGNATURE</code>
-        </td>
-        <td>Operator key doesn't match operator account</td>
-        <td>Verify OPERATOR_KEY matches your OPERATOR_ID</td>
-      </tr>
-      <tr>
-        <td>
-          <code>INVALID_ACCOUNT_ID</code>
-        </td>
-        <td>Malformed account ID in environment variables</td>
-        <td>
-          Verify OPERATOR_ID format is <code>0.0.1234</code>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <code>INVALID_PRIVATE_KEY</code>
-        </td>
-        <td>Malformed private key in environment variables</td>
-        <td>Verify OPERATOR_KEY is a valid DER-encoded private key string</td>
-      </tr>
-      <tr>
-        <td>
-          <code>KEY_REQUIRED</code>
-        </td>
-        <td>Missing key in AccountCreateTransaction</td>
-        <td>
-          Ensure you call <code>.setECDSAKeyWithAlias(newPublicKey)</code>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <code>OPERATOR_ID and OPERATOR_KEY must be set</code>
-        </td>
-        <td>Environment variables not accessible</td>
-        <td>
-          Check environment variables are set and accessible to your application
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <code>Cannot read properties of undefined</code>
-        </td>
-        <td>Missing imports or undefined variables</td>
-        <td>Verify all imports are included and variables are defined</td>
-      </tr>
-    </tbody>
-  </table>
+| Error message | Likely cause | Fix |
+| --- | --- | --- |
+| `INSUFFICIENT_PAYER_BALANCE` | Operator account lacks enough ℏ for the fee. | Top-up your testnet account with the [HBAR faucet](https://portal.hedera.com/signup). |
+| `INVALID_SIGNATURE` | Operator key doesn't match operator account | Verify OPERATOR_KEY matches your OPERATOR_ID |
+| `INVALID_ACCOUNT_ID` | Malformed account ID in environment variables | Verify OPERATOR_ID format is `0.0.1234` |
+| `INVALID_PRIVATE_KEY` | Malformed private key in environment variables | Verify OPERATOR_KEY is a valid DER-encoded private key string |
+| `KEY_REQUIRED` | Missing key in AccountCreateTransaction | Ensure you set the account key: `setKeyWithAlias` (Java), `setECDSAKeyWithAlias` (JS/Go), `set_key_with_alias` (Python) |
+| `OPERATOR_ID and OPERATOR_KEY must be set` | Environment variables not accessible | Check environment variables are set and accessible to your application |
+| `Cannot read properties of undefined` | Missing imports or undefined variables | Verify all imports are included and variables are defined |
 </Accordion>
 
 ---

--- a/native/accounts/get-balance.mdx
+++ b/native/accounts/get-balance.mdx
@@ -36,6 +36,32 @@ console.log(balance.hbars.toString());
 //v2.87.0
 ```
 
+```java Java
+// MirrorNodeAccountBalanceQuery is free; no operator signing required.
+Hbar balance = new MirrorNodeAccountBalanceQuery()
+    .setAccountId(accountId)
+    .execute(client)
+    .hbars;
+
+System.out.println(balance);
+
+//v2.77.0
+```
+
+```go Go
+// MirrorNodeAccountBalanceQuery is free; no operator signing required.
+balance, err := hiero.NewMirrorNodeAccountBalanceQuery().
+    SetAccountID(accountId).
+    Execute(client)
+if err != nil {
+    panic(err)
+}
+
+fmt.Println(balance.Hbars.String())
+
+//v2.84.0
+```
+
 </CodeGroup>
 
 ### Querying by EVM address or account alias
@@ -58,30 +84,92 @@ const balanceByAlias = await new MirrorNodeAccountBalanceQuery()
 //v2.87.0
 ```
 
+```java Java
+// By EVM address
+Hbar balanceByEvm = new MirrorNodeAccountBalanceQuery()
+    .setAccountId(AccountId.fromString("0x0000000000000000000000000000000000bc614e"))
+    .execute(client)
+    .hbars;
+
+// By account alias
+Hbar balanceByAlias = new MirrorNodeAccountBalanceQuery()
+    .setAccountId(AccountId.fromString("0.0.302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a905d7822d6526b870d"))
+    .execute(client)
+    .hbars;
+
+//v2.77.0
+```
+
+```go Go
+// By EVM address
+byEvm, _ := hiero.AccountIDFromString("0x0000000000000000000000000000000000bc614e")
+balanceByEvm, err := hiero.NewMirrorNodeAccountBalanceQuery().
+    SetAccountID(byEvm).
+    Execute(client)
+
+// By account alias
+byAlias, _ := hiero.AccountIDFromString("0.0.302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a905d7822d6526b870d")
+balanceByAlias, err := hiero.NewMirrorNodeAccountBalanceQuery().
+    SetAccountID(byAlias).
+    Execute(client)
+
+//v2.84.0
+```
+
 </CodeGroup>
 
 ### Behavioral differences from `AccountBalanceQuery`
 
-The HBAR balance result is equivalent, but the behavior in edge cases differs. The first three points are the migration essentials; the last two come from the SDK implementation and matter for high-balance accounts and custom retry logic.
+The HBAR balance result is equivalent, but the behavior in edge cases differs. Eventual consistency and unknown-account handling are the migration essentials; the precision and retry notes come from the SDK implementation and matter for high-balance accounts and custom retry logic.
 
 <Warning>
-* **Eventual consistency.** The mirror node ingests blocks asynchronously a few seconds after consensus, so a balance read immediately after `getReceipt()` may still show the pre-transaction value. Poll until the balance changes, or rely on the transaction receipt for confirmation rather than a balance read. (The SDK source describes the result as not read-after-write consistent.)
-* **Non-existent account returns `hbars = 0`,** not a thrown `INVALID_ACCOUNT_ID` error. The mirror node returns an empty array for unknown accounts rather than a 404. If your code catches that error to detect a missing account, check for a zero balance instead.
-* **No `setContractId`.** Pass contract IDs, EVM addresses, and account aliases through `setAccountId`.
-* **Precision.** In the JavaScript SDK, balances above `Number.MAX_SAFE_INTEGER` lose precision silently. Account for this on very high-balance accounts.
-* **Error handling asymmetry.** 5xx responses and network timeouts are retried with exponential backoff, but 4xx responses throw immediately. If you wrap this query in your own retry logic, do not retry on 4xx.
+* **Eventual consistency:** The mirror node ingests blocks asynchronously a few seconds after consensus, so a balance read immediately after `getReceipt()` may still show the pre-transaction value. Poll until the balance changes, or rely on the transaction receipt for confirmation rather than a balance read.
+* **Unknown-account handling differs by SDK.** The mirror node returns an empty array (HTTP 200) for an account it does not know, and each SDK maps that differently:
+  * **JavaScript** returns `hbars = 0`, which is indistinguishable from a real account that holds zero HBAR. Do not use a zero balance to infer that an account is missing.
+  * **Java** throws `INVALID_ACCOUNT_ID`, matching the deprecated `AccountBalanceQuery`.
+  * **Go** returns an `INVALID_ACCOUNT_ID` error, matching the deprecated `AccountBalanceQuery` (see [detecting a missing account](#detecting-a-missing-account-in-go)).
+* **No `setContractId`:** Pass contract IDs, EVM addresses, and account aliases through `setAccountId`.
+* **Precision (JavaScript only):** In the JavaScript SDK, balances above `Number.MAX_SAFE_INTEGER` lose precision silently. The Java (`Hbar`/`long`) and Go (`Hbar`/`int64`) SDKs are not affected.
+* **Retry behavior:** Transient failures are retried automatically with exponential backoff, so a wrapper retry loop is usually unnecessary. The exact retried set differs by SDK (see [Retry behavior by SDK](#retry-behavior-by-sdk)). In your own retry logic, never retry a 4xx other than 429: a 4xx means the request itself is invalid (for example, a malformed account ID) and will fail again.
 </Warning>
+
+#### Detecting a missing account in Go
+
+The Go error is the same precheck-status error the deprecated `AccountBalanceQuery` returned, so you branch on its status:
+
+```go
+balance, err := hiero.NewMirrorNodeAccountBalanceQuery().
+    SetAccountID(id).
+    Execute(client)
+
+// errors is the standard library package.
+var pre hiero.ErrHederaPreCheckStatus
+if errors.As(err, &pre) && pre.Status == hiero.StatusInvalidAccountID {
+    // No such account on the mirror node.
+}
+```
+
+#### Retry behavior by SDK
+
+Each SDK retries transient failures automatically; the retried set differs. In every SDK, a plain 4xx (other than 429) is treated as a bad request and is not retried.
+
+| Failure | JavaScript | Java | Go |
+| --- | --- | --- | --- |
+| Network timeout, 5xx | Retried | Retried | Retried |
+| 429 (rate limit) | Not retried | Retried | Retried |
+| 408 (request timeout) | Not retried | Retried | Not retried |
+| Other 4xx | Not retried | Not retried | Not retried |
 
 ## SDK Versions
 
 `MirrorNodeAccountBalanceQuery` is available in:
 
 - **JavaScript** ([`@hiero-ledger/sdk`](https://www.npmjs.com/package/@hiero-ledger/sdk)): [v2.87.0+](https://github.com/hiero-ledger/hiero-sdk-js/releases/tag/v2.87.0)
-- **Java**: coming soon
-- **Go**: coming soon
+- **Java** ([`com.hedera.hashgraph:sdk`](https://central.sonatype.com/artifact/com.hedera.hashgraph/sdk/2.77.0)): [v2.77.0+](https://github.com/hiero-ledger/hiero-sdk-java/releases/tag/v2.77.0)
+- **Go** ([`github.com/hiero-ledger/hiero-sdk-go/v2`](https://pkg.go.dev/github.com/hiero-ledger/hiero-sdk-go/v2)): [v2.84.0+](https://github.com/hiero-ledger/hiero-sdk-go/releases/tag/v2.84.0)
 - **Rust**: not available
 
-For Rust, and for Java and Go until those ship, read HBAR balances from the [Mirror Node REST API](/reference/rest-api/balances) directly.
+For Rust, read HBAR balances from the [Mirror Node REST API](/reference/rest-api/balances) directly.
 
 ## Token balances
 
@@ -138,7 +226,7 @@ console.log("The hbar account balance for this account is " +accountBalance.hbar
 
 ```go Go
 //Create the account balance query
-query := hedera.NewAccountBalanceQuery().
+query := hiero.NewAccountBalanceQuery().
      SetAccountID(newAccountId)
 
 //Sign with client operator private key and submit the query to a Hedera network
@@ -154,16 +242,18 @@ fmt.Println("The hbar account balance for this account is ", accountBalance.Hbar
 
 
 ```rust Rust
-// Create the query
-let query = AccountBalanceQuery::new()
-    .account_id(account_id);
+use hiero_sdk::AccountBalanceQuery;
 
-// Sign with client operator private key and submit to a Hedera network
-let account_balance = query.execute(&client).await?;
+// Create and execute the query
+let account_balance = AccountBalanceQuery::new()
+    .account_id(account_id)
+    .execute(&client)
+    .await?;
 
-println!("The account balance is {:?}", account_balance.hbars);
+// Print the balance of hbars
+println!("balance = {}", account_balance.hbars);
 
-// v0.34.0
+// v0.45.0
 ```
 
 </CodeGroup>

--- a/native/accounts/get-balance.mdx
+++ b/native/accounts/get-balance.mdx
@@ -76,10 +76,13 @@ const balanceByEvm = await new MirrorNodeAccountBalanceQuery()
     .setAccountId("0x0000000000000000000000000000000000bc614e")
     .execute(client);
 
+console.log(balanceByEvm.hbars.toString());
+
 //By account alias
 const balanceByAlias = await new MirrorNodeAccountBalanceQuery()
     .setAccountId("0.0.302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a905d7822d6526b870d")
     .execute(client);
+console.log(balanceByAlias.hbars.toString());
 
 //v2.87.0
 ```
@@ -90,28 +93,44 @@ Hbar balanceByEvm = new MirrorNodeAccountBalanceQuery()
     .setAccountId(AccountId.fromString("0x0000000000000000000000000000000000bc614e"))
     .execute(client)
     .hbars;
+System.out.println(balanceByEvm);
 
 // By account alias
 Hbar balanceByAlias = new MirrorNodeAccountBalanceQuery()
     .setAccountId(AccountId.fromString("0.0.302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a905d7822d6526b870d"))
     .execute(client)
     .hbars;
+System.out.println(balanceByAlias);
 
 //v2.77.0
 ```
 
 ```go Go
 // By EVM address
-byEvm, _ := hiero.AccountIDFromString("0x0000000000000000000000000000000000bc614e")
+byEvm, err := hiero.AccountIDFromString("0x0000000000000000000000000000000000bc614e")
+if err != nil {
+    panic(err)
+}
 balanceByEvm, err := hiero.NewMirrorNodeAccountBalanceQuery().
     SetAccountID(byEvm).
     Execute(client)
+if err != nil {
+    panic(err)
+}
+fmt.Println(balanceByEvm.Hbars.String())
 
 // By account alias
-byAlias, _ := hiero.AccountIDFromString("0.0.302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a905d7822d6526b870d")
+byAlias, err := hiero.AccountIDFromString("0.0.302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a905d7822d6526b870d")
+if err != nil {
+    panic(err)
+}
 balanceByAlias, err := hiero.NewMirrorNodeAccountBalanceQuery().
     SetAccountID(byAlias).
     Execute(client)
+if err != nil {
+    panic(err)
+}
+fmt.Println(balanceByAlias.Hbars.String())
 
 //v2.84.0
 ```

--- a/native/quickstart/go.mdx
+++ b/native/quickstart/go.mdx
@@ -25,10 +25,10 @@ Create a `.env` file (and add it to `.gitignore`):
 
 ```dotenv
 OPERATOR_ID=0.0.1234
-OPERATOR_KEY=302d300706052b8104000a032200033456...
+OPERATOR_KEY=3030020100300706052b8104000a04220420a1b2c...
 ```
 
-`OPERATOR_ID` is your Hedera account ID. `OPERATOR_KEY` is the DER-encoded ECDSA private key; use the **HEX Encoded Private Key** value from the developer portal.
+`OPERATOR_ID` is your Hedera account ID (for example, `0.0.1234`). `OPERATOR_KEY` is your account's **ECDSA private key**: copy the **DER Encoded Private Key** (starts with `303...`) from the developer portal.
 
 ## Step 3: Connect, query, transfer
 
@@ -42,7 +42,7 @@ import (
     "log"
     "os"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
     "github.com/joho/godotenv"
 )
 
@@ -51,23 +51,23 @@ func main() {
         log.Fatalf("failed to load .env: %v", err)
     }
 
-    operatorID, err := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+    operatorID, err := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
     if err != nil {
         log.Fatalf("bad OPERATOR_ID: %v", err)
     }
 
-    operatorKey, err := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+    operatorKey, err := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
     if err != nil {
         log.Fatalf("bad OPERATOR_KEY: %v", err)
     }
 
     // Connect to testnet with the operator as the default payer.
-    client := hedera.ClientForTestnet()
+    client := hiero.ClientForTestnet()
     client.SetOperator(operatorID, operatorKey)
 
-    // 1. Query the operator's balance.
-    // AccountBalanceQuery is deprecated, see /native/accounts/get-balance
-    balance, err := hedera.NewAccountBalanceQuery().
+    // 1. Query the operator's balance (free mirror node read).
+    // MirrorNodeAccountBalanceQuery replaces the deprecated AccountBalanceQuery.
+    balance, err := hiero.NewMirrorNodeAccountBalanceQuery().
         SetAccountID(operatorID).
         Execute(client)
     if err != nil {
@@ -76,10 +76,10 @@ func main() {
     fmt.Printf("Operator balance: %v\n", balance.Hbars)
 
     // 2. Transfer 1 HBAR to account 0.0.3.
-    recipient, _ := hedera.AccountIDFromString("0.0.3")
-    response, err := hedera.NewTransferTransaction().
-        AddHbarTransfer(operatorID, hedera.HbarFrom(-1, hedera.HbarUnits.Hbar)).
-        AddHbarTransfer(recipient, hedera.HbarFrom(1, hedera.HbarUnits.Hbar)).
+    recipient, _ := hiero.AccountIDFromString("0.0.3")
+    response, err := hiero.NewTransferTransaction().
+        AddHbarTransfer(operatorID, hiero.HbarFrom(-1, hiero.HbarUnits.Hbar)).
+        AddHbarTransfer(recipient, hiero.HbarFrom(1, hiero.HbarUnits.Hbar)).
         Execute(client)
     if err != nil {
         log.Fatalf("transfer failed: %v", err)

--- a/native/quickstart/java.mdx
+++ b/native/quickstart/java.mdx
@@ -20,12 +20,17 @@ For Maven, add to `pom.xml`:
     <dependency>
         <groupId>com.hedera.hashgraph</groupId>
         <artifactId>sdk</artifactId>
-        <version>2.72.0</version>
+        <version>2.77.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
-        <version>1.73.0</version>
+        <version>1.83.1</version>
+    </dependency>
+    <dependency>
+        <groupId>io.github.cdimascio</groupId>
+        <artifactId>dotenv-java</artifactId>
+        <version>3.0.0</version>
     </dependency>
 </dependencies>
 ```
@@ -34,8 +39,9 @@ For Gradle, add to `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'com.hedera.hashgraph:sdk:2.72.0'
-    implementation 'io.grpc:grpc-netty-shaded:1.73.0'
+    implementation 'com.hedera.hashgraph:sdk:2.77.0'
+    implementation 'io.grpc:grpc-netty-shaded:1.83.1'
+    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 }
 ```
 
@@ -47,10 +53,10 @@ Create a `.env` file in your project root (and add it to `.gitignore`):
 
 ```dotenv
 OPERATOR_ID=0.0.1234
-OPERATOR_KEY=302d300706052b8104000a032200033456...
+OPERATOR_KEY=3030020100300706052b8104000a04220420a1b2c...
 ```
 
-`OPERATOR_ID` is your Hedera account ID. `OPERATOR_KEY` is the DER-encoded ECDSA private key; use the **HEX Encoded Private Key** value from the developer portal.
+`OPERATOR_ID` is your Hedera account ID (for example, `0.0.1234`). `OPERATOR_KEY` is your account's **ECDSA private key**: copy the **DER Encoded Private Key** (starts with `303...`) from the developer portal.
 
 ## Step 3: Connect, query, transfer
 
@@ -65,15 +71,15 @@ public class HederaQuickstart {
     public static void main(String[] args) throws Exception {
         Dotenv env = Dotenv.load();
         AccountId operatorId = AccountId.fromString(env.get("OPERATOR_ID"));
-        PrivateKey operatorKey = PrivateKey.fromString(env.get("OPERATOR_KEY"));
+        PrivateKey operatorKey = PrivateKey.fromStringECDSA(env.get("OPERATOR_KEY"));
 
         // Connect to testnet using the operator account as the default payer.
         Client client = Client.forTestnet();
         client.setOperator(operatorId, operatorKey);
 
-        // 1. Query the operator's balance.
-        // AccountBalanceQuery is deprecated, see /native/accounts/get-balance
-        Hbar balance = new AccountBalanceQuery()
+        // 1. Query the operator's balance (free mirror node read).
+        // MirrorNodeAccountBalanceQuery replaces the deprecated AccountBalanceQuery.
+        Hbar balance = new MirrorNodeAccountBalanceQuery()
             .setAccountId(operatorId)
             .execute(client)
             .hbars;
@@ -94,8 +100,6 @@ public class HederaQuickstart {
     }
 }
 ```
-
-Add a `.env` loader to your dependencies if you don't have one. `io.github.cdimascio:dotenv-java:3.0.0` is the common pick.
 
 ## Step 4: Run it
 

--- a/native/quickstart/javascript.mdx
+++ b/native/quickstart/javascript.mdx
@@ -1,87 +1,132 @@
 ---
-title: "Quickstart"
+title: "JavaScript Quickstart"
+description: "Connect to Hedera testnet from JavaScript, query your balance, and transfer HBAR."
 ---
 
+This page gets a Node.js application talking to Hedera testnet: SDK install, operator credentials, balance query, and an HBAR transfer.
 
-This quickstart walks you through submitting your first Hedera transaction using the playground, creating and funding a testnet account via the developer portal, and viewing the transaction on HashScan.
+## Prerequisites
 
-***
+- Node.js 18 or later
+- A Hedera testnet account with ECDSA keys from the [developer portal](https://portal.hedera.com)
 
-## Submit Your First Transaction
+## Step 1: Initialize the project and install the SDK
 
-<Steps>
-<Step title="Open the Playground">
-
-<Card
-  horizontal
-  title="OPEN PLAYGROUND"
-  href="https://portal.hedera.com/playground"
-  icon="rectangle-terminal"
-/>
-</Step>
-
-<Step title="Transfer HBAR transaction">
-
-Under the **Account & HBAR** native services, click the **Transfer HBAR** transaction from the left navigation
-
-1. Replace `receiverAccount` with account ID "0.0.800"
-2. Then click on **Get Account Balance** under Queries
-</Step>
-
-<Step title="Execute transaction">
-
-Click the **Execute** button to submit your first transaction.
-
-<Frame>
-  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-1.png" />
-</Frame>
-</Step>
-
-<Step title="Create a Hedera testnet account">
-
-When you click **Execute**, you’ll be prompted to sign up for a developer portal account. Once logged in, click the **CREATE ACCOUNT** button to complete the testnet account creation flow.
-
-<div><Frame>
-  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-2.png" />
-</Frame> <Frame>
-  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-3.png" />
-</Frame> <Frame>
-  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-4.png" />
-</Frame></div>
-
-Your new testnet account will be automatically funded with **1000 HBAR**. View your account ID and key pair from the portal dashboard.
-
-<Frame>
-  <img src="/images/getting-started-hedera-native-developers/quickstart/quickstart-5.png" />
-</Frame>
-</Step>
-
-<Step title="View the transaction on HashScan">
-
-View and verify the transaction details and success confirmation. Click the HashScan link from the transaction output on the playground. View your transaction details, account history, and network activity.
-
-```
--------------------------------- Transfer HBAR ------------------------------ 
-Receipt status           : SUCCESS
-Transaction ID           : 0.0.6239936@1751330868.909246536
-<strong>Hashscan URL             : https://hashscan.io/testnet/tx/0.0.6239936@1751330868.909246536
-</strong>-------------------------------- Account Balance ------------------------------
-HBAR account balance     : 995.99724961 ℏ
-Token account balance    : {}
-
+```bash
+mkdir hedera-quickstart && cd hedera-quickstart
+npm init -y
+npm install --save @hiero-ledger/sdk
+npm install dotenv
 ```
 
-</Step>
-</Steps>
+Enable ES module imports by adding `"type": "module"` to your `package.json`:
 
-***
+```json
+{
+  "type": "module"
+}
+```
+
+## Step 2: Credentials
+
+Create a `.env` file (and add it to `.gitignore`):
+
+```dotenv
+OPERATOR_ID=0.0.1234
+OPERATOR_KEY=3030020100300706052b8104000a04220420a1b2c...
+```
+
+`OPERATOR_ID` is your Hedera account ID (for example, `0.0.1234`). `OPERATOR_KEY` is your account's **ECDSA private key**: copy the **DER Encoded Private Key** (starts with `303...`) from the developer portal.
+
+## Step 3: Connect, query, transfer
+
+Create `index.js`:
+
+```javascript
+import {
+    Client,
+    AccountId,
+    PrivateKey,
+    Hbar,
+    MirrorNodeAccountBalanceQuery,
+    TransferTransaction,
+} from "@hiero-ledger/sdk";
+import "dotenv/config";
+
+async function main() {
+    const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+    const operatorKey = PrivateKey.fromStringECDSA(process.env.OPERATOR_KEY);
+
+    // Connect to testnet using the operator account as the default payer.
+    const client = Client.forTestnet().setOperator(operatorId, operatorKey);
+
+    // 1. Query the operator's balance (free mirror node read).
+    // MirrorNodeAccountBalanceQuery replaces the deprecated AccountBalanceQuery.
+    const balance = await new MirrorNodeAccountBalanceQuery()
+        .setAccountId(operatorId)
+        .execute(client);
+    console.log("Operator balance:", balance.hbars.toString());
+
+    // 2. Transfer 1 HBAR to account 0.0.3 (a test recipient).
+    const response = await new TransferTransaction()
+        .addHbarTransfer(operatorId, new Hbar(-1))
+        .addHbarTransfer("0.0.3", new Hbar(1))
+        .execute(client);
+
+    const receipt = await response.getReceipt(client);
+    console.log("Transfer status:", receipt.status.toString());
+    console.log("Transaction ID:", response.transactionId.toString());
+
+    client.close();
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});
+```
+
+## Step 4: Run it
+
+```bash
+node index.js
+```
+
+Expected output:
+
+```text
+Operator balance: 10000 ℏ
+Transfer status: SUCCESS
+Transaction ID: 0.0.1234@1700000000.123456789
+```
+
+Look up the transaction on HashScan:
+
+```text
+https://hashscan.io/testnet/transaction/<transactionId>
+```
 
 <Tip>
 **Prefer a local network?** [Solo](https://solo.hiero.org/docs/) runs a full Hedera stack on your machine, no testnet rate limits, no faucet, no resets. See [Using Solo with Hiero SDKs](https://solo.hiero.org/docs/using-solo/using-solo-with-hiero-sdks/) to point the SDK at a local Solo network instead of testnet.
 </Tip>
 
-## Next Step
+## What's next
 
-* [Create an Account](/learn/getting-started/create-portal-account)
-* [Create a Token](/native/tutorials/tokens/create-first-token)
-* [Create a Topic](/native/tutorials/consensus/create-first-topic)
+<CardGroup cols={2}>
+  <Card title="Create an Account" icon="user-plus" href="/native/accounts/create">
+    Generate a new account programmatically and fund it from your operator.
+  </Card>
+  <Card title="Create a Token" icon="coins" href="/native/tokens/define">
+    Mint a native HTS token with custom supply and decimals.
+  </Card>
+  <Card title="Submit to a Topic" icon="comment" href="/native/consensus/submit-message">
+    Publish a message to HCS for verifiable, ordered audit logs.
+  </Card>
+  <Card title="SDK Reference" icon="book" href="https://github.com/hiero-ledger/hiero-sdk-js">
+    Full API reference on GitHub.
+  </Card>
+</CardGroup>
+
+<Tip>
+  The four Hiero SDKs (JavaScript, Java, Go, Python) share the same API surface, so code translates almost line-for-line between them. Differences are mostly language-idiomatic.
+</Tip>

--- a/native/tutorials/consensus/create-first-topic.mdx
+++ b/native/tutorials/consensus/create-first-topic.mdx
@@ -39,7 +39,7 @@ npm init -y
 Ensure you have [**Node.js**](https://nodejs.org/en/download) `v18` or later installed on your machine. Then, install the[ JavaScript SDK](https://github.com/hiero-ledger/hiero-sdk-js).
 
 ```bash
-npm install --save @hashgraph/sdk
+npm install --save @hiero-ledger/sdk
 ```
 
 Update your `package.json` file to enable ES6 modules and configure the project:
@@ -57,7 +57,7 @@ Update your `package.json` file to enable ES6 modules and configure the project:
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hashgraph/sdk": "^2.69.0"
+    "@hiero-ledger/sdk": "^2.87.0"
   }
 }
 ```
@@ -69,7 +69,7 @@ import {
   Client,
   TopicCreateTransaction,
   TopicMessageSubmitTransaction,
-} from "@hashgraph/sdk";
+} from "@hiero-ledger/sdk";
 ```
 
 </Tab>
@@ -84,17 +84,17 @@ Create a new **Maven** project and name it `HederaExamples`. Add the following d
     <dependency>
         <groupId>com.hedera.hashgraph</groupId>
         <artifactId>sdk</artifactId>
-        <version>2.61.0</version>
+        <version>2.77.0</version>
     </dependency>
     <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.10.1</version>
+        <version>2.14.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
-        <version>1.73.0</version>
+        <version>1.83.1</version>
     </dependency>
 </dependencies>
 ```
@@ -112,9 +112,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.hedera.hashgraph:sdk:2.60.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'io.grpc:grpc-netty-shaded:1.61.0'
+    implementation 'com.hedera.hashgraph:sdk:2.77.0'
+    implementation 'com.google.code.gson:gson:2.14.0'
+    implementation 'io.grpc:grpc-netty-shaded:1.83.1'
 }
 
 application {
@@ -157,7 +157,7 @@ import (
     "os"
     "time"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 )
 ```
 
@@ -258,7 +258,7 @@ Set your operator credentials as environment variables. Your `OPERATOR_ID` is yo
 
 ```bash
 export OPERATOR_ID="0.0.1234"
-export OPERATOR_KEY="3030020100300506032b657004220420..."
+export OPERATOR_KEY="3030020100300706052b8104000a04220420..."
 ```
 
 ---
@@ -282,7 +282,7 @@ const client = Client.forTestnet()
 ```java Java
 // Load your operator credentials
 AccountId operatorId = AccountId.fromString(System.getenv("OPERATOR_ID"));
-PrivateKey operatorKey = PrivateKey.fromString(System.getenv("OPERATOR_KEY"));
+PrivateKey operatorKey = PrivateKey.fromStringECDSA(System.getenv("OPERATOR_KEY"));
 
 // Initialize your testnet client and set operator
 Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
@@ -290,18 +290,18 @@ Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
 
 ```go Go
 // Load your operator credentials
-operatorId, _ := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
-operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+operatorId, _ := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+operatorKey, _ := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
 
 // Initialize the client for testnet
-client := hedera.ClientForTestnet()
+client := hiero.ClientForTestnet()
 client.SetOperator(operatorId, operatorKey)
 ```
 
 ```python Python
 # Load your operator credentials
 operatorId = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-operatorKey = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+operatorKey = PrivateKey.from_string_der(os.getenv("OPERATOR_KEY", ""))
 
 # Initialize your testnet client and set operator
 client = Client()
@@ -349,7 +349,7 @@ System.out.println("Topic created: " + topicId);
 
 ```go Go
 // build & execute the topic creation transaction
-transaction := hedera.NewTopicCreateTransaction().
+transaction := hiero.NewTopicCreateTransaction().
     SetTopicMemo("My first HCS topic")
 
 txResponse, err := transaction.Execute(client)
@@ -430,7 +430,7 @@ System.out.println("\nMessage submitted: " + message);
 // build & execute the message submission transaction
 message := "Hello, Hedera!"
 
-messageTransaction := hedera.NewTopicMessageSubmitTransaction().
+messageTransaction := hiero.NewTopicMessageSubmitTransaction().
     SetTopicID(topicID).
     SetMessage([]byte(message))
 
@@ -649,7 +649,7 @@ import {
   Client,
   TopicCreateTransaction,
   TopicMessageSubmitTransaction,
-} from "@hashgraph/sdk";
+} from "@hiero-ledger/sdk";
 
 async function createTopicDemo() {
 // load your operator credentials
@@ -730,7 +730,7 @@ public class CreateTopicDemo {
 
         // initialize the client for testnet
         Client client = Client.forTestnet()
-            .setOperator(AccountId.fromString(operatorId), PrivateKey.fromString(operatorKey));
+            .setOperator(AccountId.fromString(operatorId), PrivateKey.fromStringECDSA(operatorKey));
 
         // build & execute the topic creation transaction
         TopicCreateTransaction transaction = new TopicCreateTransaction()
@@ -802,21 +802,21 @@ import (
 	"strings"
 	"time"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 
 )
 
 func main() {
 // load your operator credentials
-operatorId, _ := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
-operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+operatorId, _ := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+operatorKey, _ := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
 
     // initialize the client for testnet
-    client := hedera.ClientForTestnet()
+    client := hiero.ClientForTestnet()
     client.SetOperator(operatorId, operatorKey)
 
     // build & execute the topic creation transaction
-    transaction := hedera.NewTopicCreateTransaction().
+    transaction := hiero.NewTopicCreateTransaction().
     	SetTopicMemo("My first HCS topic")
 
     txResponse, err := transaction.Execute(client)
@@ -836,7 +836,7 @@ operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
     // build & execute the message submission transaction
     message := "Hello, Hedera!"
 
-    messageTransaction := hedera.NewTopicMessageSubmitTransaction().
+    messageTransaction := hiero.NewTopicMessageSubmitTransaction().
     	SetTopicID(topicID).
     	SetMessage([]byte(message))
 
@@ -909,7 +909,7 @@ from hiero_sdk_python import (
 
 # load your operator credentials
 operatorId = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-operatorKey = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+operatorKey = PrivateKey.from_string_der(os.getenv("OPERATOR_KEY", ""))
 
 # initialize the client for testnet
 client = Client()
@@ -979,7 +979,7 @@ Ensure your environment variables are set:
 
 ```bash
 export OPERATOR_ID="0.0.1234"
-export OPERATOR_KEY="3030020100300506032b657004220420..."
+export OPERATOR_KEY="3030020100300706052b8104000a04220420..."
 ```
 
 <Tabs>

--- a/native/tutorials/tokens/create-first-token.mdx
+++ b/native/tutorials/tokens/create-first-token.mdx
@@ -39,7 +39,7 @@ npm init -y
 Ensure you have [**Node.js**](https://nodejs.org/en/download) `v18` or later installed on your machine. Then, install the[ JavaScript SDK](https://github.com/hiero-ledger/hiero-sdk-js).
 
 ```bash
-npm install --save @hashgraph/sdk
+npm install --save @hiero-ledger/sdk
 ```
 
 Update your `package.json` file to enable ES6 modules and configure the project:
@@ -57,7 +57,7 @@ Update your `package.json` file to enable ES6 modules and configure the project:
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hashgraph/sdk": "^2.69.0"
+    "@hiero-ledger/sdk": "^2.87.0"
   }
 }
 ```
@@ -70,7 +70,7 @@ import {
   PrivateKey,
   TokenCreateTransaction,
   TokenSupplyType,
-} from "@hashgraph/sdk";
+} from "@hiero-ledger/sdk";
 ```
 
 </Tab>
@@ -85,17 +85,17 @@ Create a new **Maven** project and name it `HederaExamples`. Add the following d
     <dependency>
         <groupId>com.hedera.hashgraph</groupId>
         <artifactId>sdk</artifactId>
-        <version>2.61.0</version>
+        <version>2.77.0</version>
     </dependency>
     <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.10.1</version>
+        <version>2.14.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
-        <version>1.73.0</version>
+        <version>1.83.1</version>
     </dependency>
 </dependencies>
 ```
@@ -113,9 +113,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.hedera.hashgraph:sdk:2.60.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'io.grpc:grpc-netty-shaded:1.61.0'
+    implementation 'com.hedera.hashgraph:sdk:2.77.0'
+    implementation 'com.google.code.gson:gson:2.14.0'
+    implementation 'io.grpc:grpc-netty-shaded:1.83.1'
 }
 
 application {
@@ -157,7 +157,7 @@ import (
     "os"
     "time"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 )
 ```
 
@@ -264,7 +264,7 @@ Set your operator credentials as environment variables. Your `OPERATOR_ID` is yo
 
 ```bash
 export OPERATOR_ID="0.0.1234"
-export OPERATOR_KEY="3030020100300506032b657004220420..."
+export OPERATOR_KEY="3030020100300706052b8104000a04220420..."
 ```
 
 ---
@@ -287,7 +287,7 @@ const client = Client.forTestnet().setOperator(operatorId, operatorKey);
 ```java Java wrap
 // Load your operator credentials
 AccountId operatorId = AccountId.fromString(System.getenv("OPERATOR_ID"));
-PrivateKey operatorKey = PrivateKey.fromString(System.getenv("OPERATOR_KEY"));
+PrivateKey operatorKey = PrivateKey.fromStringECDSA(System.getenv("OPERATOR_KEY"));
 
 // Initialize your testnet client and set operator
 Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
@@ -295,18 +295,18 @@ Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
 
 ```go Go wrap
 // Load your operator credentials
-operatorId, _ := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
-operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+operatorId, _ := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+operatorKey, _ := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
 
 // Initialize the client for testnet
-client := hedera.ClientForTestnet()
+client := hiero.ClientForTestnet()
 client.SetOperator(operatorId, operatorKey)
 ```
 
 ```python Python wrap
 # Load your operator credentials
 operatorId = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-operatorKey = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+operatorKey = PrivateKey.from_string_der(os.getenv("OPERATOR_KEY", ""))
 
 # Initialize your testnet client and set operator
 client = Client()
@@ -339,7 +339,7 @@ PrivateKey adminKey = supplyKey; // can update/delete (reuse for simplicity)
 
 ```go Go
 // Generate keys that control your token
-supplyKey, _ := hedera.PrivateKeyGenerateEcdsa() // can mint/burn
+supplyKey, _ := hiero.PrivateKeyGenerateEcdsa() // can mint/burn
 adminKey := supplyKey // can update/delete (reuse for simplicity)
 ```
 
@@ -411,12 +411,12 @@ System.out.println("\nFungible token created: " + tokenId);
 
 ```go Go
 // Build the transaction
-transaction, _ := hedera.NewTokenCreateTransaction().
+transaction, _ := hiero.NewTokenCreateTransaction().
         SetTokenName("Demo Token").
         SetTokenSymbol("DEMO").
         SetDecimals(2).
         SetInitialSupply(100_000).
-        SetSupplyType(hedera.TokenSupplyTypeFinite).
+        SetSupplyType(hiero.TokenSupplyTypeFinite).
         SetMaxSupply(100_000).
         SetTreasuryAccountID(operatorId).
         SetAdminKey(adminKey.PublicKey()).
@@ -621,7 +621,7 @@ import {
   PrivateKey,
   TokenCreateTransaction,
   TokenSupplyType
-} from "@hashgraph/sdk";
+} from "@hiero-ledger/sdk";
 
 async function createTokenDemo() {
 // load your operator credentials
@@ -697,7 +697,7 @@ public class CreateTokenDemo {
     public static void main(String[] args ) throws Exception {
         // load your operator credentials
         AccountId operatorId = AccountId.fromString(System.getenv("OPERATOR_ID"));
-        PrivateKey operatorKey = PrivateKey.fromString(System.getenv("OPERATOR_KEY"));
+        PrivateKey operatorKey = PrivateKey.fromStringECDSA(System.getenv("OPERATOR_KEY"));
 
         // initialize the client for testnet
         Client client = Client.forTestnet().setOperator(operatorId, operatorKey);
@@ -769,30 +769,30 @@ import (
     "os"
     "time"
 
-    hedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+    hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 
 )
 
 func main() {
 // load your operator credentials
-operatorId, _ := hedera.AccountIDFromString(os.Getenv("OPERATOR_ID"))
-operatorKey, _ := hedera.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+operatorId, _ := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+operatorKey, _ := hiero.PrivateKeyFromStringECDSA(os.Getenv("OPERATOR_KEY"))
 
     // initialize the client for testnet
-    client := hedera.ClientForTestnet()
+    client := hiero.ClientForTestnet()
     client.SetOperator(operatorId, operatorKey)
 
     // generate token keys
-    supplyKey, _ := hedera.PrivateKeyGenerateEcdsa()
+    supplyKey, _ := hiero.PrivateKeyGenerateEcdsa()
     adminKey := supplyKey
 
     // build & execute the token creation transaction
-    transaction, _ := hedera.NewTokenCreateTransaction().
+    transaction, _ := hiero.NewTokenCreateTransaction().
     	SetTokenName("Demo Token").
     	SetTokenSymbol("DEMO").
     	SetDecimals(2).
     	SetInitialSupply(100_000).
-    	SetSupplyType(hedera.TokenSupplyTypeFinite).
+    	SetSupplyType(hiero.TokenSupplyTypeFinite).
     	SetMaxSupply(100_000).
     	SetTreasuryAccountID(operatorId).
     	SetAdminKey(adminKey.PublicKey()).
@@ -859,7 +859,7 @@ from hiero_sdk_python import (
 
 # Load your operator credentials
 operatorId = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-operatorKey = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+operatorKey = PrivateKey.from_string_der(os.getenv("OPERATOR_KEY", ""))
 
 # Initialize the client for testnet
 client = Client()
@@ -921,7 +921,7 @@ Ensure your environment variables are set:
 
 ```bash
 export OPERATOR_ID="0.0.1234"
-export OPERATOR_KEY="3030020100300506032b657004220420..."
+export OPERATOR_KEY="3030020100300706052b8104000a04220420..."
 ```
 
 <Tabs>
@@ -985,7 +985,13 @@ Treasury holds: 100000 DEMO
 ### ‼️ Troubleshooting
 
 <Accordion title="Common ERROR messages and solutions ⬇️">
-<table><thead><tr><th>Symptom</th><th>Likely cause</th><th>Fix</th></tr></thead><tbody><tr><td><code>INSUFFICIENT_PAYER_BALANCE</code></td><td>Not enough HBAR for transaction fees</td><td>Top up your operator account on the testnet faucet</td></tr><tr><td><code>INVALID_SIGNATURE</code></td><td>Not signing the transaction with the admin key or treasury account</td><td>Add <code>.sign(privateKey)</code>to the transaction before executing it</td></tr><tr><td><code>TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT</code></td><td>Account already associated with token</td><td>This is normal for treasury accounts - ignore this error</td></tr><tr><td><code>INVALID_ACCOUNT_ID</code></td><td>Malformed account ID in environment variables</td><td>Verify <code>OPERATOR_ID</code> format is <strong><code>0.0.1234</code></strong></td></tr><tr><td><code>INVALID_PRIVATE_KEY</code></td><td>Malformed private key in environment variables</td><td>Verify OPERATOR_KEY is a valid DER-encoded private key string</td></tr></tbody></table>
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `INSUFFICIENT_PAYER_BALANCE` | Not enough HBAR for transaction fees | Top up your operator account on the testnet faucet |
+| `INVALID_SIGNATURE` | Not signing the transaction with the admin key or treasury account | Add `.sign(privateKey)` to the transaction before executing it |
+| `TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT` | Account already associated with token | This is normal for treasury accounts; ignore this error |
+| `INVALID_ACCOUNT_ID` | Malformed account ID in environment variables | Verify `OPERATOR_ID` format is `0.0.1234` |
+| `INVALID_PRIVATE_KEY` | Malformed private key in environment variables | Verify OPERATOR_KEY is a valid DER-encoded private key string |
 
 #### Environment Issues:
 


### PR DESCRIPTION
## what

swaps in `MirrorNodeAccountBalanceQuery` for java/go now that it has shipped, and aligns native sdk examples across the quickstart/getting-started pages.

## changes

- **get-balance**: add java (v2.77.0) and go (v2.84.0) tabs to the `MirrorNodeAccountBalanceQuery` codegroups; document per-sdk unknown-account behavior (js returns 0, java/go raise `INVALID_ACCOUNT_ID`) and a retry-behavior matrix; update the deprecated rust sample to `hiero_sdk` / v0.45.0.
- **quickstarts (js/java/go)**: rewrite the js quickstart to match java/go (install → code → run); standardize on the `hiero` go import, a single ecdsa der `OPERATOR_KEY`, and `fromStringECDSA` parsing; bump deps (`@hiero-ledger/sdk` 2.87.0, java 2.77.0, gson 2.14.0, grpc 1.83.1).
- **create-portal-account**: fold the developer-portal walkthrough in as the group's intro; modernize all imports/deps; fix the ecdsa der key, per-sdk parse method, python `set_key_with_alias`, and convert the html troubleshooting table to markdown.
- **create-first-topic / create-first-token**: same sweep — `@hiero-ledger/sdk` scope, dep bumps, `hiero` alias, ecdsa der key + correct parse, html table → markdown.

## notes

- code verified against the js/java/go/rust sdk sources at their release tags
- rust keeps `AccountBalanceQuery` (no `MirrorNodeAccountBalanceQuery` upstream yet)
- `mint broken-links` passes

closes #724
