### PR TITLE
docs: add frontmatter descriptions across 7 tabs (#732)

### DIFF
--- a/evm/development/addresses.mdx
+++ b/evm/development/addresses.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Contract Addresses"
+description: "Learn the two ways a Hedera smart contract is referenced: its EVM address and its native contract ID, and how each is used across Ethereum tools and Hedera transactions."
 ---
 
 

--- a/evm/development/archive-queries.mdx
+++ b/evm/development/archive-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "EVM Archive Node Queries"
+description: "Use Hedera mirror node EVM archive queries (HIP-584) to run gas-free smart contract calls, estimate gas, and simulate transactions without committing state changes."
 ---
 
 

--- a/evm/development/compiling.mdx
+++ b/evm/development/compiling.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Compiling Smart Contracts"
+description: "Compile Solidity smart contracts into EVM bytecode and an ABI with solc and tools like Remix or Hardhat before deploying to Hedera."
 ---
 
 Compiling a smart contract involves using the contract's source code to generate its [**bytecode**](/support/glossary#bytecode) and the contract [**Application** **Binary Interface (ABI)**](/support/glossary#application-binary-interface-abi). The Ethereum Virtual Machine (EVM) executes the bytecode to understand and execute the smart contract. Meanwhile, other smart contracts use the ABI to understand how to interact with the deployed contracts on the Hedera network.

--- a/evm/development/creating.mdx
+++ b/evm/development/creating.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Creating Smart Contracts"
+description: "Write your first Hedera smart contract in Solidity or Vyper, understand state variables and functions, and see how source code compiles to EVM bytecode."
 ---
 
 

--- a/evm/development/deploying.mdx
+++ b/evm/development/deploying.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploying Smart Contracts"
+description: "Deploy smart contracts to Hedera: how the Besu EVM executes bytecode and opcodes, the Cancun hard fork, and the ContractCreate, EthereumTransaction, and eth_sendRawTransaction paths."
 ---
 
 

--- a/evm/development/forking.mdx
+++ b/evm/development/forking.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Forking Hedera Network for Local Testing"
+description: "Learn how fork testing works on Hedera, how it differs from other EVM chains, and how the hedera-forking library enables local testing against Hedera System Contracts."
 ---
 
 This guide explains how fork testing works on Hedera, how it differs from traditional EVM chains, and how the [hedera-forking](https://github.com/hashgraph/hedera-forking) library enables local development with Hedera System Contracts.

--- a/evm/development/json-rpc/index.mdx
+++ b/evm/development/json-rpc/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "JSON-RPC Relay"
+description: "Learn how the Hiero JSON-RPC Relay implements the EVM JSON-RPC standard for Hedera, covering HBAR decimal handling and options from local node to hosted relays."
 ---
 
 The [Hiero JSON-RPC Relay](https://github.com/hiero-ledger/hiero-json-rpc-relay) is an open-source project implementing the EVM JSON-RPC standard. It allows developers to interact with Hedera nodes using familiar EVM tools, allowing developers and users to deploy, query, and execute contracts as they usually would. Check out the interactive[ OpenRPC Specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false) and a simple [list of endpoints](https://github.com/hiero-ledger/hiero-json-rpc-relay/blob/main/docs/rpc-api.md).

--- a/evm/development/rent.mdx
+++ b/evm/development/rent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Contract Rent"
+description: "Understand how smart contract rent works on Hedera, including contract auto-renewal and storage payments, and how these mechanisms keep contracts active on the network."
 ---
 
 

--- a/evm/development/security.mdx
+++ b/evm/development/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Contract Security"
+description: "Understand the Hedera Smart Contract Service security model, EVM equivalence, and how key-signature authorization evolved from the v1 boundaries to the current model."
 ---
 
 

--- a/evm/development/traceability.mdx
+++ b/evm/development/traceability.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Contract Traceability"
+description: "Investigate smart contract execution on Hedera using call traces and state traces to analyze, debug, and audit function calls, inputs, outputs, and gas usage."
 ---
 
 

--- a/evm/development/verifying.mdx
+++ b/evm/development/verifying.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Verifying Smart Contracts"
+description: "Verify that deployed smart contract bytecode matches your source code on Hedera using Sourcify, and see the verified status surface automatically on HashScan."
 ---
 
 

--- a/evm/differences/hbar-decimals.mdx
+++ b/evm/differences/hbar-decimals.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Decimal Handling (8 vs. 18 Decimals)"
+description: "Understand the 8 vs. 18 decimal differences between HBAR, HTS tokens, and ERC tokens across HAPI, the EVM, and the JSON-RPC relay, and how to avoid scaling errors."
 ---
 
 

--- a/evm/differences/index.mdx
+++ b/evm/differences/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Understanding Hedera's EVM Differences and Compatibility
+description: "Understand how Hedera's EVM-compatible environment differs from Ethereum across account models, key management, token handling, and JSON-RPC behavior when building or migrating contracts."
 sidebarTitle: Hedera vs. Ethereum
 ---
 

--- a/evm/differences/native-devs/ed25519-integration.mdx
+++ b/evm/differences/native-devs/ed25519-integration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Integrating
       ED25519 Accounts and Advanced Features Into Smart Contracts"
+description: "Integrate ED25519 accounts, multi-sig, and threshold keys into Hedera smart contracts, using the HIP-632 isAuthorized and isAuthorizedRaw functions to verify signatures on-chain."
 ---
 ## Overview
 

--- a/evm/differences/native-devs/extending-token-management.mdx
+++ b/evm/differences/native-devs/extending-token-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Extending Token Management with Smart Contracts"
+description: "Add programmable logic to HTS tokens with smart contracts on Hedera, enabling conditional minting, burning, and transfers while securely managing the supply key."
 ---
 
 

--- a/evm/differences/native-devs/index.mdx
+++ b/evm/differences/native-devs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: For Hedera-Native Developers Adding Smart Contract Functionality
+description: "A guide for Hedera-native developers adding EVM smart contract functionality: key management, state queries via mirror nodes, extending HTS, and signature verification."
 sidebarTitle: For Native Devs
 ---
 ## **Introduction**

--- a/evm/differences/native-devs/json-rpc-state-queries.mdx
+++ b/evm/differences/native-devs/json-rpc-state-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "JSON-RPC Relay and State Queries"
+description: "Understand how Hedera's JSON-RPC relay behaves differently from Ethereum for state queries, and how to adapt workflows using mirror nodes for Hedera-native apps."
 ---
 
 

--- a/evm/differences/native-token-transfers.mdx
+++ b/evm/differences/native-token-transfers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Handling HBAR Transfers in Contracts"
+description: "Handle HBAR transfers in Hedera smart contracts with Solidity's transfer, send, and call, and understand how receive and fallback functions behave differently than on Ethereum."
 ---
 
 

--- a/evm/differences/tooling-compatibility.mdx
+++ b/evm/differences/tooling-compatibility.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Management with Hedera Token Service"
+description: "See how HBAR differs from Ethereum's ETH burning and how EVM developers mint and burn custom tokens with the Hedera Token Service supply key and HTS system contract."
 ---
 
 

--- a/evm/hedera-services/hybrid/erc-compatibility.mdx
+++ b/evm/hedera-services/hybrid/erc-compatibility.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ERC/EVM-Compatible Tokenization"
+description: "Deploy and interact with ERC-20, ERC-721, and other EVM token contracts on Hedera using familiar tools like Hardhat, ethers.js, and Remix through the JSON-RPC relay."
 ---
 
 

--- a/evm/hedera-services/hybrid/index.mdx
+++ b/evm/hedera-services/hybrid/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hybrid (HTS + EVM ) Tokenization"
+description: "Learn hybrid tokenization on Hedera, combining native HTS tokens with EVM smart contracts so contracts can manage HTS tokens as if they were standard ERC tokens."
 ---
 
 

--- a/evm/hedera-services/system-contracts/hts.mdx
+++ b/evm/hedera-services/system-contracts/hts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Token Service System Contract"
+description: "Call the Hedera Token Service system contract from Solidity to create, mint, burn, transfer, and manage HTS tokens directly from the EVM, with a full function reference."
 sidebarTitle: "Token Service"
 ---
 

--- a/evm/hedera-services/system-contracts/index.mdx
+++ b/evm/hedera-services/system-contracts/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: System Smart Contracts
+description: "Reference for Hedera system smart contracts: reserved EVM addresses that expose native Hedera APIs like the exchange rate, token, account, and schedule services to Solidity."
 sidebarTitle: System Contracts
 ---
 System smart contracts are Hedera API functionality logic presented at reserved address locations on the EVM network. These addresses contain reserved function selectors. When a deployed contract calls these selectors, they execute as though a corresponding system contract exists on the network. Both system and user-deployed contracts live at the same address. If a contract is redeployed, it gets a new address while the original address retains the old bytecode.

--- a/evm/hedera-services/system-contracts/schedule-service.mdx
+++ b/evm/hedera-services/system-contracts/schedule-service.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Schedule Service"
+description: "Use the Hedera Schedule Service (HSS) system contract to schedule future transactions and contract calls on-chain, coordinate multi-sig, and automate execution without off-chain bots."
 sidebarTitle: "Schedule Service"
 mode: "wide"
 ---

--- a/evm/integrations/oracles/chainlink.mdx
+++ b/evm/integrations/oracles/chainlink.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chainlink Oracles"
+description: "Connect Hedera smart contracts to real-world data using Chainlink oracles and price feeds for building data-driven decentralized applications."
 ---
 
 

--- a/evm/integrations/oracles/pyth.mdx
+++ b/evm/integrations/oracles/pyth.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pyth Oracles"
+description: "Integrate Pyth Network price feeds into Hedera smart contracts using its pull-based update model to bring real-time crypto, equity, FX, and commodity data on-chain."
 ---
 
 

--- a/evm/integrations/oracles/supra.mdx
+++ b/evm/integrations/oracles/supra.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Supra Oracles"
+description: "Integrate Supra decentralized oracle price feeds into Hedera dApps for real-time asset data, with guidance on mirror node data payload limits for contract calls."
 ---
 
 

--- a/evm/integrations/wallets/metamask-snap.mdx
+++ b/evm/integrations/wallets/metamask-snap.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hedera Wallet Snap By MetaMask
+description: "Use the Hedera Wallet Snap for MetaMask to interact directly with the Hedera network, sending HBAR and retrieving account information without the JSON-RPC relay."
 sidebarTitle: MetaMask Snap
 ---
 ## Overview

--- a/evm/integrations/wallets/walletconnect.mdx
+++ b/evm/integrations/wallets/walletconnect.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera WalletConnect"
+description: "Integrate Hedera with WalletConnect to connect wallets and dApps across the Hedera network."
 url: "https://github.com/hashgraph/hedera-wallet-connect?tab=readme-ov-file#overview"
 ---

--- a/evm/quickstart/deploy-with-contract-builder.mdx
+++ b/evm/quickstart/deploy-with-contract-builder.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy your First Contract with Hedera Contract Builder"
+description: "Deploy your first smart contract to Hedera testnet in minutes using the browser-based Hedera Contract Builder from the Hedera Developer Portal."
 ---
 
 

--- a/evm/quickstart/deploy-with-foundry.mdx
+++ b/evm/quickstart/deploy-with-foundry.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy and Verify a Smart Contract with Foundry"
+description: "Write, compile, deploy, and verify an ERC-20 smart contract on Hedera using Foundry, forge, and cast, connecting through the JSON-RPC relay."
 ---
 
 ## Deploying a Contract Using Foundry

--- a/evm/quickstart/deploy-with-hardhat.mdx
+++ b/evm/quickstart/deploy-with-hardhat.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy and Verify a Smart Contract with Hardhat"
+description: "Write, compile, deploy, verify, and interact with an ERC-721 smart contract on Hedera using Hardhat and Ethers.js through the JSON-RPC relay."
 ---
 
 ## Deploying a Contract Using Hardhat Scripts

--- a/evm/quickstart/portal-contract-builder.mdx
+++ b/evm/quickstart/portal-contract-builder.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera Contract Builder"
+description: "Redirect to the Hedera Contract Builder tool for compiling and deploying smart contracts from the browser."
 url: "/evm/tools/contract-builder"
 ---

--- a/evm/quickstart/setup-metamask.mdx
+++ b/evm/quickstart/setup-metamask.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Add Hedera to MetaMask"
+description: "Add Hedera mainnet and testnet to MetaMask by configuring the JSON-RPC endpoint, chain ID, and HBAR currency symbol as a custom network."
 ---
 
 

--- a/evm/tokens/erc1363.mdx
+++ b/evm/tokens/erc1363.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ERC-1363 (Payable Tokens)"
+description: "Learn the ERC-1363 payable token standard, which extends ERC-20 to trigger smart contract actions immediately after a transfer or approval, and how to use it on Hedera."
 ---
 
 

--- a/evm/tokens/erc20.mdx
+++ b/evm/tokens/erc20.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ERC-20 (Fungible Tokens)"
+description: "Use the ERC-20 fungible token standard on Hedera, including supported functions and how ERC-20 addresses map to native Hedera Token Service token entities."
 ---
 
 

--- a/evm/tokens/erc3643.mdx
+++ b/evm/tokens/erc3643.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ERC-3643 (Real World Assets)"
+description: "Implement ERC-3643 permissioned tokens for real-world assets on Hedera, with on-chain identity, KYC, and AML compliance rules enforced on every transfer."
 ---
 
 

--- a/evm/tokens/erc721.mdx
+++ b/evm/tokens/erc721.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ERC-721 (Non-Fungible Tokens)"
+description: "Use the ERC-721 non-fungible token standard on Hedera, including supported functions and how ERC-721 addresses map to native Hedera Token Service NFT entities."
 ---
 
 

--- a/evm/tokens/index.mdx
+++ b/evm/tokens/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tokens Managed by Smart Contracts
+description: "Learn how ERC token standards work on Hedera, how smart contracts create and manage tokens, and how HTS tokens can be treated as ERC-20 or ERC-721 contracts."
 sidebarTitle: ERC Tokens
 ---
 A [smart contract](/support/glossary#smart-contract) is a programmable, self-executing agreement designed to create, manage, or enforce the conditions of digital assets, also known as tokens. Tokens managed by smart contracts serve as digital representations of various asset types, such as artwork, cryptocurrency, and carbon credits on the blockchain. These tokens allow assets to be securely transferred between users or contracts and interact with others, adding functionality and interoperability within the blockchain ecosystem.

--- a/evm/tokens/whbar.mdx
+++ b/evm/tokens/whbar.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wrapped HBAR (WHBAR)"
+description: "Learn how Wrapped HBAR (WHBAR) wraps native HBAR as an ERC-20 token, using deposit() to mint WHBAR and withdraw() to burn it back to HBAR for DeFi and web3 integrations."
 ---
 
 

--- a/evm/tools/contract-builder.mdx
+++ b/evm/tools/contract-builder.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Contract Builder"
+description: "Scaffold, compile, deploy, and verify Solidity contracts on Hedera testnet from your browser with the interactive Hedera Contract Builder playground, no CLI or local setup required."
 mode: "custom"
 ---
 

--- a/evm/tools/foundry/forking-advanced-hts.mdx
+++ b/evm/tools/foundry/forking-advanced-hts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Fork the Hedera Network with Foundry - Advanced HTS Contract (Part 2)"
+description: "Fork the Hedera network with Foundry to create HTS tokens via System Contract precompiles, query token info, and test ERC-20 interactions using the hedera-forking layer."
 sidebarTitle: "Forking: Advanced"
 ---
 

--- a/evm/tools/foundry/forking.mdx
+++ b/evm/tools/foundry/forking.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Fork the Hedera Network with Foundry - Basic ERC-20 Contract (Part 1)"
+description: "Fork Hedera testnet with Foundry and interact with a basic ERC-20 token, deploying a contract and running tests against forked network state."
 sidebarTitle: "Forking: Basics"
 ---
 

--- a/evm/tools/foundry/index.mdx
+++ b/evm/tools/foundry/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Foundry on Hedera
+description: "Set up Foundry and use Forge to build, test, and deploy smart contracts on Hedera, and fork the network to test against deployed contracts."
 ---
 
 Foundry empowers developers with tools for smart contract development. One of the three main components of Foundry is Forge. Forge is a Foundry command-line tool that allows developers to run tests, build, and deploy smart contracts.

--- a/evm/tools/foundry/setup.mdx
+++ b/evm/tools/foundry/setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Foundry with Hedera Localnet/Testnet: A Step-by-Step Guide"
+description: "Configure Foundry to work with the Hiero Local Node and JSON-RPC relay for local deployment, debugging, and testing of Hedera smart contracts without using testnet resources."
 sidebarTitle: "Foundry Setup"
 ---
 

--- a/evm/tools/hardhat/forking-advanced.mdx
+++ b/evm/tools/hardhat/forking-advanced.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Fork the Hedera Network with Hardhat - Advanced HTS Contract (Part 2)"
+description: "Fork the Hedera network with Hardhat to create, mint, and transfer HTS tokens via System Contract precompiles, and learn the limits of the forking emulation layer."
 sidebarTitle: "Forking: Advanced"
 ---
 

--- a/evm/tools/hardhat/forking-basic.mdx
+++ b/evm/tools/hardhat/forking-basic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Fork the Hedera Network with Hardhat - Basic ERC-20 Contract (Part 1)"
+description: "Fork Hedera testnet with Hardhat and TypeScript to interact with a basic ERC-20 token, deploying a contract and running tests against forked network state."
 sidebarTitle: "Forking: Basics"
 ---
 

--- a/evm/tools/hardhat/index.mdx
+++ b/evm/tools/hardhat/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Hardhat with Hedera Localnet/Testnet: A Step-by-Step Guide"
+description: "Configure Hardhat to work with the Hiero Local Node and JSON-RPC relay for local deployment, debugging, and testing of Hedera smart contracts without using testnet resources."
 sidebarTitle: "Hardhat Configuration"
 ---
 

--- a/evm/tools/other/the-graph.mdx
+++ b/evm/tools/other/the-graph.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy a Subgraph Using The Graph and Hedera JSON-RPC Relay"
+description: "Create and deploy a subgraph on Hedera using The Graph and the JSON-RPC relay, indexing network data and querying it through a GraphQL API for your dApp."
 sidebarTitle: "The Graph"
 ---
 

--- a/evm/tools/other/truffle.mdx
+++ b/evm/tools/other/truffle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Smart Contracts on Hedera Using Truffle"
+description: "Deploy and interact with smart contracts on Hedera using Truffle and the JSON-RPC relay, from creating an ECDSA account to compiling and deploying a contract."
 sidebarTitle: "Truffle"
 ---
 

--- a/evm/tutorials/advanced/erc721-foundry/part1-mint-burn.mdx
+++ b/evm/tutorials/advanced/erc721-foundry/part1-mint-burn.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Mint & Burn an ERC-721 Token using Foundry(Part 1)"
+description: "Deploy, mint, and burn ERC-721 NFTs on Hedera testnet using Foundry and OpenZeppelin, with forge scripts and cast for RPC interactions via Hashio."
 ---
 
 In this tutorial, you’ll deploy, mint, and burn ERC‑721 tokens (NFTs) using Foundry and OpenZeppelin on the Hedera Testnet. You’ll set up a Foundry project, write an ERC‑721 contract, deploy it via a Foundry script, mint an NFT to your account, add burn functionality, and burn an NFT.

--- a/evm/tutorials/advanced/erc721-foundry/part2-testing.mdx
+++ b/evm/tutorials/advanced/erc721-foundry/part2-testing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Write Tests in Solidity(Part 2)"
+description: "Write Solidity unit tests for an ERC-721 mint-and-burn contract with Foundry, using cheatcodes like prank, expectRevert, and fuzzing on a local in-memory EVM."
 ---
 
 In this tutorial, you’ll learn how to write Solidity unit tests with Foundry for an ERC‑721 (NFT) contract that supports minting and burning. We’ll cover:

--- a/evm/tutorials/advanced/erc721-hardhat/part1-mint-burn.mdx
+++ b/evm/tutorials/advanced/erc721-hardhat/part1-mint-burn.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Mint & Burn an ERC-721 Token Using Hardhat and Ethers (Part 1)"
+description: "Deploy, mint, and burn ERC-721 NFTs on Hedera testnet using Hardhat, Ethers, and OpenZeppelin contracts."
 ---
 
 In this tutorial, you'll learn how to deploy, mint, and burn [ERC-721](/support/glossary#erc-721) tokens (NFTs) using Hardhat, Ethers, and OpenZeppelin contracts on the Hedera Testnet. We'll cover setting up your project, writing and deploying an ERC-721 smart contract, minting an NFT to your account, and finally, burning an NFT.

--- a/evm/tutorials/advanced/erc721-hardhat/part2-access-control.mdx
+++ b/evm/tutorials/advanced/erc721-hardhat/part2-access-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Set Access Control, a Token URI, Pause, and Transfer an ERC-721 Token Using Hardhat (Part 2)"
+description: "Add access control roles, token URI storage, pausing, and transfers to an ERC-721 contract on Hedera using Hardhat and OpenZeppelin."
 ---
 
 In this tutorial, you'll learn how to create and manage an advanced ERC-721 token smart contract using Hardhat and OpenZeppelin. We'll cover deploying the contract, minting NFTs, pausing and unpausing the contract, and transferring tokens. You'll gain experience with [Access Control](https://docs.openzeppelin.com/contracts/5.x/access-control#using-access-control) (admin, minting, pausing roles), URI storage, and Pausable functionalities.

--- a/evm/tutorials/advanced/erc721-hardhat/part3-upgradeable.mdx
+++ b/evm/tutorials/advanced/erc721-hardhat/part3-upgradeable.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Upgrade an ERC-721 Token with OpenZeppelin UUPS Proxies and Hardhat (Part 3)"
+description: "Upgrade an ERC-721 smart contract on Hedera with Hardhat using UUPS-ready contracts deployed behind an OpenZeppelin Transparent proxy, with step-by-step implementation and upgrade verification."
 ---
 
 In this tutorial, you'll learn how to upgrade your ERC-721 smart contract using the OpenZeppelin UUPS (Universal Upgradeable Proxy Standard) pattern and Hardhat. We'll first cover how the upgradeable proxy pattern works, then go through step-by-step implementation and upgrade verification, explaining each part clearly.

--- a/evm/tutorials/beginner/connect-metamask.mdx
+++ b/evm/tutorials/beginner/connect-metamask.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Connect MetaMask to Hedera"
+description: "Connect MetaMask to the Hedera network using three methods: through HashScan, manual network configuration, or ChainList."
 ---
 
 [**Download the MetaMask wallet**](https://metamask.io/download/), then configure the Hedera network/testnet settings in the MM network settings with one of the three methods below:

--- a/evm/tutorials/hedera/hss-evm/part1-schedule-calls.mdx
+++ b/evm/tutorials/hedera/hss-evm/part1-schedule-calls.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HSS x EVM - Schedule Smart Contract Calls (Part 1)"
+description: "Build an on-chain AlarmClock contract on Hedera that schedules one-shot and recurring smart contract calls using the Hedera Schedule Service, with no off-chain bots."
 ---
 
 On most EVM chains like Ethereum, smart contracts cannot "wake up" on their own—every function call must be triggered by an externally owned account (EOA) or an off-chain bot. This means implementing time-based automation (like cron jobs) requires external infrastructure.

--- a/evm/tutorials/hedera/hss-evm/part2-rebalancing.mdx
+++ b/evm/tutorials/hedera/hss-evm/part2-rebalancing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HSS x EVM - Dynamic Rebalancing Through Scheduled Execution (Part 2)"
+description: "Build a capacity-aware DeFi rebalancer on Hedera that queries network capacity and uses exponential backoff to schedule self-sustaining on-chain execution via the Schedule Service."
 ---
 
 In [Part 1](/evm/tutorials/hedera/hss-evm/part1-schedule-calls), you learned how to schedule future smart contract calls using Hedera's Schedule Service. Now, let's build something more sophisticated: a **capacity-aware DeFi rebalancer** that automatically adjusts its scheduling strategy based on network conditions.

--- a/evm/tutorials/hedera/hts-evm/part1-mint-nfts.mdx
+++ b/evm/tutorials/hedera/hts-evm/part1-mint-nfts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HTS x EVM - How to Mint NFTs (Part 1)"
+description: "Create an NFT collection with a royalty fee, mint NFTs with IPFS metadata, and burn an NFT on Hedera by calling the HTS system contract from a Solidity contract."
 ---
 
 On Hedera, we can create, mint, burn and transfer non-fungible tokens(NFTs) without deploying or dealing with any smart contracts. We can do this using only the Hedera Token Service(HTS) and official SDKs available in varrious languages such as Javascript, Rust, Go, Python, Java, etc. If you want to learn how to perform these operations using the SDK, refer to [this documentation](/native/tutorials/tokens/hts-part1-mint).

--- a/evm/tutorials/hedera/hts-evm/part2-kyc-update.mdx
+++ b/evm/tutorials/hedera/hts-evm/part2-kyc-update.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HTS x EVM - KYC & Update (Part 2)"
+description: "Configure and permission native Hedera tokens from a Solidity contract, granting and revoking KYC flags and rotating the KYC key with the HTS system contract."
 ---
 
 In [Part 1](/evm/tutorials/hedera/hts-evm/part1-mint-nfts) of the series, you saw how to mint, transfer, and burn an NFT using Hedera'a EVM and [Hedera Token Service (HTS) System Smart Contracts](/evm/hedera-services/system-contracts). In this guide, you’ll learn the basics of how to configure / permission native Hedera Tokens via a Smart Contract. Specifically, you will learn how to:

--- a/evm/tutorials/hedera/hts-evm/part3-pause-freeze-wipe.mdx
+++ b/evm/tutorials/hedera/hts-evm/part3-pause-freeze-wipe.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HTS x EVM - How to Pause, Freeze, Wipe, and Delete NFTs (Part 3)"
+description: "Pause, freeze, wipe, and delete native Hedera tokens from a Solidity contract using the Hedera Token Service system contract."
 ---
 
 In [HTS x EVM - Part 2](/evm/tutorials/hedera/hts-evm/part2-kyc-update), you learned how to grant / revoke KYC and manage a token using the [Hedera Token Service (HTS) System Smart Contract](/evm/hedera-services/system-contracts#hedera-token-service). But those aren't all the token operations you can do!

--- a/evm/tutorials/hedera/hybrid-hts-evm.mdx
+++ b/evm/tutorials/hedera/hybrid-hts-evm.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hybrid (HTS + EVM ) Tokenization"
+description: "Learn hybrid tokenization on Hedera, combining native HTS tokens with EVM smart contracts so contracts can manage HTS tokens as if they were standard ERC tokens."
 ---
 
 ## **Hybrid Tokenization: Combining HTS and Smart Contracts**

--- a/evm/tutorials/hedera/nft-solidity.mdx
+++ b/evm/tutorials/hedera/nft-solidity.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create and Transfer an NFT using a Solidity Contract"
+description: "Create, mint, and transfer an NFT on Hedera by calling the Hedera Token Service from a Solidity contract using the provided HederaTokenService helper contracts."
 ---
 
 

--- a/evm/tutorials/intermediate/json-rpc-connections/hashio.mdx
+++ b/evm/tutorials/intermediate/json-rpc-connections/hashio.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Hashio RPC endpoints"
+description: "Configure the free public Hashio JSON-RPC endpoint to connect EVM-compatible developer tools to Hedera mainnet, testnet, and previewnet."
 ---
 
 How to configure a JSON-RPC endpoint that enables communication between EVM-compatible developer tools using Hashio.

--- a/evm/tutorials/intermediate/json-rpc-connections/validation-cloud.mdx
+++ b/evm/tutorials/intermediate/json-rpc-connections/validation-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configuring Validation Cloud RPC endpoints"
+description: "Configure Validation Cloud's managed JSON-RPC endpoint to connect EVM tools to Hedera, with a free tier and no rate limits for higher-volume apps."
 ---
 
 [Validation Cloud](https://www.validationcloud.io/node)

--- a/evm/tutorials/intermediate/send-receive-hbar.mdx
+++ b/evm/tutorials/intermediate/send-receive-hbar.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Send and Receive HBAR Using Solidity Smart Contracts"
+description: "Send and receive HBAR with Hedera smart contracts using Solidity's transfer, send, and call methods, plus payable, fallback, and receive functions."
 ---
 
 Smart contracts on Hedera can hold and exchange value in the form of HBAR, Hedera Token Service (HTS) tokens, and even ERC tokens. This is fundamental for building decentralized applications that rely on contracts in areas like DeFi, ESG, NFT marketplaces, DAOs, and more.

--- a/evm/tutorials/intermediate/verify-hashscan.mdx
+++ b/evm/tutorials/intermediate/verify-hashscan.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Verify a Smart Contract on HashScan"
+description: "Verify a smart contract so its source appears on HashScan by submitting your source and metadata to Sourcify, which supports Hedera mainnet and testnet."
 ---
 
 Verifying smart contracts proves that the deployed bytecode matches the source files you publish. On Hedera, verification is handled by [Sourcify](https://sourcify.dev), which natively supports Hedera Mainnet (chain ID `295`) and Testnet (chain ID `296`). Once a contract is verified on Sourcify, [HashScan](https://hashscan.io/) automatically picks up the verified status and displays the source code on the contract page.

--- a/learn/core-concepts/accounts/hiero-hooks.mdx
+++ b/learn/core-concepts/accounts/hiero-hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hiero Hooks"
+description: "Learn how Hiero Hooks inject Solidity-based logic into the transaction pipeline, attaching to accounts to enforce custom rules on token transfers for account abstraction."
 ---
 
 Hiero Hooks provide programmable extension points to inject Solidity-based logic directly into the network's transaction pipeline. Hooks attach to accounts to enforce custom rules on actions like token transfers, but they do not run automatically—a hook is triggered only when explicitly referenced in a `TransferTransaction` (e.g., `CryptoTransfer`).

--- a/learn/core-concepts/accounts/network-accounts.mdx
+++ b/learn/core-concepts/accounts/network-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Accounts"
+description: "Reference for Hedera's special network-controlled accounts (0.0.98, 0.0.800, 0.0.801, 0.0.802) that handle transaction fees, staking rewards, and node rewards."
 ---
 
 The Hedera network uses several special, network-controlled accounts for its operations. These accounts are fundamental to the network's fee structure, staking rewards, and overall economic model.

--- a/learn/core-concepts/hashgraph/gossip-about-gossip.mdx
+++ b/learn/core-concepts/hashgraph/gossip-about-gossip.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Gossip About Gossip"
+description: "Learn how hashgraph consensus spreads information with a gossip protocol, and how events, parent hashes, and gossip about gossip build the hashgraph DAG."
 ---
 
 

--- a/learn/core-concepts/hashgraph/virtual-voting.mdx
+++ b/learn/core-concepts/hashgraph/virtual-voting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Virtual Voting"
+description: "Learn how the hashgraph algorithm reaches Byzantine agreement without sending votes over the network, using virtual voting to divide rounds, decide fame, and find order."
 ---
 
 

--- a/learn/core-concepts/services/smart-contracts.mdx
+++ b/learn/core-concepts/services/smart-contracts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Smart Contracts
+description: "Explore Hedera smart contracts and how the EVM differs from Ethereum: accounts and keys, JSON-RPC relay, token management, decimal handling, and HBAR transfers."
 ---
 
 

--- a/learn/core-concepts/staking/index.mdx
+++ b/learn/core-concepts/staking/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Staking
+description: "Learn how Hedera's proof-of-stake consensus works, how staking secures the network, and find answers to common questions on rewards, lock-up, and eligibility."
 ---
 The Hedera public ledger uses a [proof-of-stake](/support/glossary#proof-of-stake-pos) consensus mechanism, in which each node’s influence on consensus is proportional to the amount of cryptocurrency it has staked. A transaction is validated and placed into consensus after it is processed by nodes representing an aggregate stake of over two-thirds of the total amount of HBAR currently staked and dedicated to securing the network. Stake is expressed as an amount in HBAR. It is important to ensure that most of the cryptocurrency is actually being staked, so that the network continues to run. This information can be referenced from the latest Hedera [whitepaper](https://hedera.com/hh_whitepaper_v2.1-20200815.pdf).
 

--- a/learn/core-concepts/staking/stake-hbar.mdx
+++ b/learn/core-concepts/staking/stake-hbar.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Stake HBAR"
+description: "Get started staking HBAR to a network node: understand reward rates set by the Hedera Council, supported wallets, and how staking reward distribution works."
 ---
 
 

--- a/learn/core-concepts/staking/staking.mdx
+++ b/learn/core-concepts/staking/staking.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Staking Program"
+description: "Learn how the Hedera staking program lets you earn rewards by staking HBAR to a node, with no lock-up, bonding, or slashing, and how the staking reward account works."
 ---
 
 The Hedera staking program allows you to earn rewards by staking your HBAR to a network node. Staking helps secure the network by contributing to the node's consensus weight (voting power).

--- a/learn/core-concepts/state-and-history.mdx
+++ b/learn/core-concepts/state-and-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: "State and History"
+description: "Understand how Hedera's replicated state machine works: how nodes apply transactions in consensus order, the difference between state and history, and node storage roles."
 ---
 
 

--- a/learn/core-concepts/tokens/airdrops.mdx
+++ b/learn/core-concepts/tokens/airdrops.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Airdrops"
+description: "Learn how HIP-904 frictionless token airdrops on Hedera distribute tokens to many accounts, handling associations automatically and letting recipients claim or reject."
 ---
 
 

--- a/learn/core-concepts/tokens/creation.mdx
+++ b/learn/core-concepts/tokens/creation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Creation"
+description: "Learn how to create fungible tokens and NFTs with the Hedera Token Service: define token properties, set supply and admin keys, and get the generated token ID."
 ---
 
 

--- a/learn/core-concepts/tokens/custom-fees.mdx
+++ b/learn/core-concepts/tokens/custom-fees.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom Fee Schedule"
+description: "Learn how to set up to 10 automated, protocol-enforced custom fees per token with HTS for royalties, revenue sharing, and incentives, applied automatically on transfers."
 ---
 
 

--- a/learn/core-concepts/tokens/hts-overview.mdx
+++ b/learn/core-concepts/tokens/hts-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hedera Token Service (HTS) Native Tokenization
+description: "Overview of the Hedera Token Service: create and manage fungible tokens and NFTs natively without smart contracts, with built-in compliance, atomic swaps, and custom fees."
 sidebarTitle: HTS Overview
 ---
 ## Overview

--- a/learn/core-concepts/tokens/index.mdx
+++ b/learn/core-concepts/tokens/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tokenization on Hedera"
+description: "Learn how tokenization works on Hedera: create, manage, and transfer fungible tokens and NFTs with the Hedera Token Service across three tokenization models."
 ---
 
 

--- a/learn/core-concepts/tokens/types-and-ids.mdx
+++ b/learn/core-concepts/tokens/types-and-ids.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Types and ID Formats"
+description: "Learn the token types the Hedera Token Service supports, fungible tokens and NFTs, and how tokens are identified on the network through their ID formats."
 ---
 
 

--- a/learn/core-concepts/transactions/properties.mdx
+++ b/learn/core-concepts/transactions/properties.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transaction Properties"
+description: "Reference for Hedera transaction properties: transaction ID, node account ID, fees, valid duration, memo, batch keys, signatures, receipts, hashes, and consensus timestamps."
 ---
 
 

--- a/learn/core-concepts/transactions/scheduled.mdx
+++ b/learn/core-concepts/transactions/scheduled.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedule Transaction"
+description: "Learn how scheduled transactions let you collect required signatures on the network over time, set expiry, and queue multi-signature transactions for future execution."
 ---
 
 

--- a/learn/getting-started/create-portal-account.mdx
+++ b/learn/getting-started/create-portal-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create an Account"
+description: "Create a new Hedera testnet account using the JavaScript, Java, Go, or Python SDK, get funded keys from the developer portal, and submit your first transaction."
 icon: "user"
 ---
 

--- a/learn/getting-started/mcp-setup.mdx
+++ b/learn/getting-started/mcp-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hedera Docs MCP Server Setup Guide
+description: "Connect your AI tools to the official Hedera documentation MCP server for real-time, accurate answers using the SearchHedera tool across the full knowledge base."
 sidebarTitle: "MCP Server Setup"
 icon: "robot"
 ---

--- a/learn/getting-started/portal-playground.mdx
+++ b/learn/getting-started/portal-playground.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Developer Playground"
+description: "Try Hedera transactions in your browser: create accounts, transfer HBAR, mint tokens, and exercise core services on testnet with no SDK install or keys to manage."
 mode: "custom"
 icon: "code"
 ---

--- a/native/accounts/adjust-allowance.mdx
+++ b/native/accounts/adjust-allowance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete an allowance"
+description: "Remove approved NFT allowances from an owner's account with AccountAllowanceDeleteTransaction, and learn how to clear HBAR and fungible token allowances by setting the amount to zero."
 ---
 
 

--- a/native/accounts/approve-allowance.mdx
+++ b/native/accounts/approve-allowance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Approve an allowance"
+description: "Grant a spender an allowance to spend HBAR, fungible tokens, or NFTs on behalf of an owner account using AccountAllowanceApproveTransaction, including approval limits and signing requirements."
 ---
 
 

--- a/native/accounts/delete.mdx
+++ b/native/accounts/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete an account"
+description: "Delete an existing Hedera account with AccountDeleteTransaction, transferring its remaining HBAR to a beneficiary account with setTransferAccountId() and the required account signature."
 ---
 
 

--- a/native/accounts/errors.mdx
+++ b/native/accounts/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response Messages"
+description: "Reference for account transaction network response messages, including errors like ACCOUNT_ID_DOES_NOT_EXIST, ACCOUNT_DELETED, and INVALID_ACCOUNT_AMOUNTS, with what each one means."
 ---
 
 

--- a/native/accounts/get-balance.mdx
+++ b/native/accounts/get-balance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get account balance"
+description: "Query an account's HBAR balance for free with MirrorNodeAccountBalanceQuery, the SDK-native replacement for the deprecated AccountBalanceQuery, using account IDs, EVM addresses, or aliases."
 ---
 
 A query that returns an account's HBAR balance. Requesting a balance is free of charge and does not change account state or require network consensus.

--- a/native/accounts/get-info.mdx
+++ b/native/accounts/get-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get account info"
+description: "Query the current state of a Hedera account with AccountInfoQuery, returning keys, balance, memo, staking info, and token relationships, with guidance on using the Mirror Node REST API."
 ---
 
 

--- a/native/accounts/transfer.mdx
+++ b/native/accounts/transfer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transfer cryptocurrency"
+description: "Transfer HBAR and tokens between Hedera accounts with TransferTransaction, batch multiple transfers in one call, and spend from an owner account using approved allowances."
 ---
 
 

--- a/native/consensus/create-topic.mdx
+++ b/native/consensus/create-topic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a topic"
+description: "Create a new Hedera Consensus Service topic with TopicCreateTransaction, set an admin key, submit key, and memo, and get the new topic ID from the transaction receipt."
 ---
 
 

--- a/native/consensus/delete-topic.mdx
+++ b/native/consensus/delete-topic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete a topic"
+description: "Delete a topic from the Hedera network with TopicDeleteTransaction, which requires the admin key to sign, and understand how older messages remain accessible via the mirror node."
 ---
 
 

--- a/native/consensus/errors.mdx
+++ b/native/consensus/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response"
+description: "Reference for Hedera Consensus Service topic network response messages, including errors like INVALID_TOPIC_ID, TOPIC_DELETED, INVALID_TOPIC_ADMIN_KEY, and UNAUTHORIZED."
 ---
 
 

--- a/native/consensus/get-info.mdx
+++ b/native/consensus/get-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get topic info"
+description: "Query an HCS topic's current state with TopicInfoQuery, returning the topic ID, admin key, submit key, sequence number, and other topic properties."
 ---
 
 

--- a/native/consensus/get-message.mdx
+++ b/native/consensus/get-message.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get topic messages"
+description: "Subscribe to an HCS topic's messages from a mirror node with TopicMessageQuery for free, retrieving all messages or those within a defined start and end time."
 ---
 
 

--- a/native/consensus/update-topic.mdx
+++ b/native/consensus/update-topic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update a topic"
+description: "Update the properties of an existing HCS topic with TopicUpdateTransaction, including the memo, admin key, submit key, auto-renew settings, and fee-related fields."
 ---
 
 

--- a/native/files/append.mdx
+++ b/native/files/append.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Append to a file"
+description: "Append new content to the end of an existing file on the Hedera File Service with FileAppendTransaction, and sign with the file's key when it differs from the operator account."
 ---
 
 

--- a/native/files/create.mdx
+++ b/native/files/create.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a file"
+description: "Create a new file on the Hedera File Service with FileCreateTransaction, get its file ID from the receipt, and append larger content with FileAppendTransaction."
 ---
 
 

--- a/native/files/delete.mdx
+++ b/native/files/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete a file"
+description: "Delete a file from the Hedera network with FileDeleteTransaction, which truncates its contents to zero length and blocks further updates, appends, and expiration extensions."
 ---
 
 

--- a/native/files/errors.mdx
+++ b/native/files/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response Messages"
+description: "Reference for Hedera File Service network response messages, including statuses like FILE_DELETED, FILE_CONTENT_EMPTY, and FEE_SCHEDULE_FILE_PART_UPLOADED."
 ---
 
 

--- a/native/files/get-contents.mdx
+++ b/native/files/get-contents.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get file contents"
+description: "Query the contents of a file on the Hedera File Service with FileContentsQuery, retrieving the raw bytes stored in the file without changing its state."
 ---
 
 

--- a/native/files/get-info.mdx
+++ b/native/files/get-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get file info"
+description: "Query the current state of a file on the Hedera File Service with FileInfoQuery, returning metadata such as size, keys, expiration time, and deletion status."
 ---
 
 

--- a/native/files/update.mdx
+++ b/native/files/update.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update a file"
+description: "Update the state of an existing file on the Hedera File Service with FileUpdateTransaction, including signing requirements when changing the keys on the file."
 ---
 
 

--- a/native/fundamentals/address-book.mdx
+++ b/native/fundamentals/address-book.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Address Book"
+description: "Retrieve a network's address book of node IDs and addresses with a FileContentsQuery to a consensus node or an AddressBookQuery to a mirror node."
 ---
 
 

--- a/native/fundamentals/client.mdx
+++ b/native/fundamentals/client.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Client"
+description: "Configure an SDK client to connect to mainnet, testnet, previewnet, or a custom network, set the mirror node endpoint, and manage TLS and network updates."
 ---
 
 

--- a/native/fundamentals/hbars.mdx
+++ b/native/fundamentals/hbars.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HBAR"
+description: "Work with the SDK Hbar type: construct HBAR from amounts, strings, and tinybars, convert between units, and represent values for transactions and fees."
 ---
 
 

--- a/native/fundamentals/local-network.mdx
+++ b/native/fundamentals/local-network.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Local Network"
+description: "Run a Hedera network on your own machine for development without testnet rate limits, resets, or faucet dependencies, and point the SDK at it with Solo."
 ---
 
 import LocalNodeDeprecation from '/snippets/local-node-deprecation.mdx';

--- a/native/fundamentals/specialized-types.mdx
+++ b/native/fundamentals/specialized-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Specialized Types"
+description: "Reference for SDK specialized types like AccountId: how they are structured, their constructors and methods, and how to convert to and from strings, bytes, and EVM addresses."
 ---
 
 

--- a/native/keys/import-key.mdx
+++ b/native/keys/import-key.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Import an existing key"
+description: "Import existing keys into the SDK from strings, bytes, or PEM files, for both ECDSA and Ed25519 key types, to construct PrivateKey and PublicKey objects."
 ---
 
 

--- a/native/keys/key-list.mdx
+++ b/native/keys/key-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a key list"
+description: "Build a key list with the SDK so every key in the list must sign to modify an account, topic, token, contract, or file, using Ed25519 or ECDSA keys."
 ---
 
 

--- a/native/keys/mnemonic-generate.mdx
+++ b/native/keys/mnemonic-generate.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Generate a mnemonic phrase"
+description: "Generate a 12 or 24-word mnemonic recovery phrase with the SDK that can be used to recover the private keys associated with it."
 ---
 
 

--- a/native/keys/mnemonic-recover.mdx
+++ b/native/keys/mnemonic-recover.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Recover keys from a mnemonic phrase"
+description: "Recover a private key from a 12 or 24-word mnemonic phrase with the SDK, with or without a passphrase, using PrivateKey.fromMnemonic()."
 ---
 
 

--- a/native/keys/threshold-key.mdx
+++ b/native/keys/threshold-key.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a threshold key"
+description: "Create a threshold key with the SDK that requires a set number of keys in the list to sign, using Ed25519 or ECDSA keys, for M-of-N signing."
 ---
 
 

--- a/native/local-dev/cde/codespaces.mdx
+++ b/native/local-dev/cde/codespaces.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Run a Local Node in Codespaces"
+description: "Set up and run a Hedera local node in GitHub Codespaces using configuration-as-code, so you can develop in the cloud without a local Docker setup."
 ---
 
 import LocalNodeDeprecation from '/snippets/local-node-deprecation.mdx';

--- a/native/local-dev/cde/gitpod.mdx
+++ b/native/local-dev/cde/gitpod.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Run a Local Node in Gitpod"
+description: "Set up and run a Hedera local node in Gitpod, a cloud development environment, so you can develop without Docker or a local setup on your own machine."
 ---
 
 import LocalNodeDeprecation from '/snippets/local-node-deprecation.mdx';

--- a/native/local-dev/cde/index.mdx
+++ b/native/local-dev/cde/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to Run Hedera Local Node in a Cloud Development Environment (CDE)
+description: "Run a Hedera local node in a cloud development environment like Gitpod or Codespaces, without Docker on your own machine, and reach each service endpoint."
 sidebarTitle: Cloud Dev Environment
 ---
 

--- a/native/local-dev/setup-cli-npm.mdx
+++ b/native/local-dev/setup-cli-npm.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Set Up a Hedera Local Node using the NPM CLI"
+description: "Install and run a Hedera node locally with the @hashgraph/hedera-local NPM CLI and docker compose, from prerequisites through startup."
 ---
 
 import LocalNodeDeprecation from '/snippets/local-node-deprecation.mdx';

--- a/native/local-dev/setup-local-node.mdx
+++ b/native/local-dev/setup-local-node.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Set Up a Hedera Local Node"
+description: "Run your own Hedera local network with the CLI and Docker: spin up a consensus node, mirror node, and JSON-RPC relay to build and test without testnet limits."
 ---
 
 import LocalNodeDeprecation from '/snippets/local-node-deprecation.mdx';

--- a/native/prng.mdx
+++ b/native/prng.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pseudorandom Number Generator"
+description: "Generate a verifiable pseudorandom number on Hedera with the PRNG transaction: return 384 random bits or an integer within a set range, per HIP-351."
 ---
 
 

--- a/native/queries.mdx
+++ b/native/queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Queries"
+description: "Reference for Hedera network queries that read data without consensus, organized by service, with guidance on when to use the mirror node REST API instead."
 ---
 
 

--- a/native/scheduled/create.mdx
+++ b/native/scheduled/create.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a schedule transaction"
+description: "Create a schedule entity on the Hedera network with ScheduleCreateTransaction, wrap a transaction for deferred multi-party signing, and get the ScheduleID from the receipt."
 ---
 
 A `ScheduleCreateTransaction` is a consensus node transaction that creates a schedule entity on the Hedera network. The entity ID for a schedule transaction is called a `ScheduleID`. After successfully executing a schedule create transaction, you can retrieve the network assigned `ScheduleID` by requesting the transaction receipt. The receipt also includes the scheduled transaction ID, which can be used to request the record of the scheduled transaction after its successful execution.

--- a/native/scheduled/delete.mdx
+++ b/native/scheduled/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete a schedule transaction"
+description: "Remove a scheduled transaction from the network with ScheduleDeleteTransaction, which requires an admin key set at creation and signed by that key, or the delete fails as immutable."
 ---
 
 

--- a/native/scheduled/get-info.mdx
+++ b/native/scheduled/get-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get schedule info"
+description: "Query the current state of a scheduled transaction with ScheduleInfoQuery, returning the schedule ID, the scheduled transaction, collected signatures, and admin key."
 ---
 
 

--- a/native/scheduled/response-messages.mdx
+++ b/native/scheduled/response-messages.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response Messages"
+description: "Reference for scheduled transaction network response messages, including errors like INVALID_SCHEDULE_ID, SCHEDULE_IS_IMMUTABLE, NO_NEW_VALID_SIGNATURES, and schedule expiry statuses."
 ---
 
 

--- a/native/scheduled/schedule-id.mdx
+++ b/native/scheduled/schedule-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedule ID"
+description: "Understand the ScheduleId that identifies a scheduled transaction entity, formatted as shardNum.realmNum.scheduleNum (for example 0.0.10)."
 ---
 
 

--- a/native/scheduled/sign.mdx
+++ b/native/scheduled/sign.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sign a scheduled transaction"
+description: "Add signatures to a scheduled transaction with ScheduleSignTransaction; once all required signatures are collected, the transaction executes immediately or at its set expiration time."
 ---
 
 

--- a/native/signature-provider/local-provider.mdx
+++ b/native/signature-provider/local-provider.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Local Provider"
+description: "Use LocalProvider in the Hedera JavaScript SDK to create a provider from the HEDERA_NETWORK environment variable defined in your project's .env file."
 ---
 
 

--- a/native/signature-provider/provider.mdx
+++ b/native/signature-provider/provider.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Provider"
+description: "Use the Provider interface in the Hedera JavaScript SDK to access a network (previewnet, testnet, or mainnet) and submit any request through its call method."
 ---
 
 

--- a/native/signature-provider/signer.mdx
+++ b/native/signature-provider/signer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Signer"
+description: "Use the Signer interface in the Hedera JavaScript SDK, which is responsible for signing requests before they are submitted to a Hedera network."
 ---
 
 

--- a/native/signature-provider/wallet.mdx
+++ b/native/signature-provider/wallet.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wallet"
+description: "Use the Wallet class in the Hedera JavaScript SDK, which extends Signer to sign requests and works with a Provider that handles communication with a Hedera network."
 ---
 
 

--- a/native/smart-contracts/call.mdx
+++ b/native/smart-contracts/call.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Call a smart contract function"
+description: "Execute a state-changing smart contract function with ContractExecuteTransaction, paying gas for computation and any resulting storage."
 ---
 
 

--- a/native/smart-contracts/create.mdx
+++ b/native/smart-contracts/create.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a smart contract"
+description: "Deploy a new smart contract on Hedera with ContractCreateTransaction or ContractCreateFlow, then get the new contract ID from the receipt."
 ---
 
 

--- a/native/smart-contracts/delegate-contract-id.mdx
+++ b/native/smart-contracts/delegate-contract-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delegate Contract ID"
+description: "Understand the delegate contract ID key, a more permissive contract key that treats a contract as a signer even when it runs another contract's code via delegatecall."
 ---
 
 

--- a/native/smart-contracts/delete.mdx
+++ b/native/smart-contracts/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete a smart contract"
+description: "Delete a smart contract with ContractDeleteTransaction, signed by the admin key, transferring any remaining HBAR balance to another account."
 ---
 
 

--- a/native/smart-contracts/errors.mdx
+++ b/native/smart-contracts/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response Messages"
+description: "Reference of Hedera Smart Contract Service network response codes and what each status means for contract transactions."
 ---
 
 

--- a/native/smart-contracts/ethereum-transaction.mdx
+++ b/native/smart-contracts/ethereum-transaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ethereum transaction"
+description: "Execute a raw, RLP-encoded Ethereum transaction (type 0, 1, or 2) on Hedera with EthereumTransaction using existing EVM tooling."
 ---
 
 

--- a/native/smart-contracts/get-bytecode.mdx
+++ b/native/smart-contracts/get-bytecode.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get smart contract bytecode"
+description: "Query the runtime bytecode of a deployed smart contract with ContractByteCodeQuery from a single node without network consensus."
 ---
 
 

--- a/native/smart-contracts/get-function.mdx
+++ b/native/smart-contracts/get-function.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get a smart contract function"
+description: "Call a read-only smart contract function locally with ContractCallQuery to return its result without changing state or reaching consensus."
 ---
 
 

--- a/native/smart-contracts/get-info.mdx
+++ b/native/smart-contracts/get-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get smart contract info"
+description: "Query the current state of a smart contract, including its balance, with ContractInfoQuery or the Mirror Node REST API."
 ---
 
 

--- a/native/smart-contracts/solidity-libraries.mdx
+++ b/native/smart-contracts/solidity-libraries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Service Solidity Libraries"
+description: "Solidity source files and libraries for calling the Hedera Token Service and other Hedera services natively from smart contracts."
 ---
 
 

--- a/native/smart-contracts/update.mdx
+++ b/native/smart-contracts/update.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update a smart contract"
+description: "Modify a smart contract entity's admin key, auto-renew period, memo, and other mutable properties with ContractUpdateTransaction."
 ---
 
 

--- a/native/tokens/airdrop.mdx
+++ b/native/tokens/airdrop.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Airdrop a token"
+description: "Send fungible tokens and NFTs to multiple accounts with TokenAirdropTransaction, holding transfers as pending airdrops when recipients aren't associated."
 ---
 
 

--- a/native/tokens/associate.mdx
+++ b/native/tokens/associate.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Associate tokens to an account"
+description: "Associate a Hedera account with one or more tokens using TokenAssociateTransaction so it can receive and hold those tokens."
 ---
 
 

--- a/native/tokens/atomic-swaps.mdx
+++ b/native/tokens/atomic-swaps.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Atomic swaps"
+description: "Swap HTS tokens and HBAR between two accounts in a single TransferTransaction, with no third-party exchange or custodian required."
 ---
 
 

--- a/native/tokens/burn.mdx
+++ b/native/tokens/burn.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Burn a token"
+description: "Burn fungible tokens or NFTs held by the treasury account with TokenBurnTransaction, decreasing the token's total supply."
 ---
 
 

--- a/native/tokens/cancel.mdx
+++ b/native/tokens/cancel.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cancel a token"
+description: "Cancel pending token airdrops you initiated with TokenCancelAirdropTransaction, removing them from network state before recipients claim them."
 ---
 
 

--- a/native/tokens/claim.mdx
+++ b/native/tokens/claim.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Claim a token"
+description: "Claim a pending token airdrop as the recipient with TokenClaimAirdropTransaction, associating and transferring the token in a single step."
 ---
 
 

--- a/native/tokens/custom-fees.mdx
+++ b/native/tokens/custom-fees.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Custom token fees"
+description: "Configure fixed, fractional, and royalty custom fees on HTS tokens that pay out automatically to fee collector accounts on every transfer."
 ---
 
 

--- a/native/tokens/define.mdx
+++ b/native/tokens/define.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a token"
+description: "Create a fungible or non-fungible token on Hedera with TokenCreateTransaction, setting its keys, supply, treasury, and other properties."
 ---
 
 

--- a/native/tokens/delete.mdx
+++ b/native/tokens/delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Delete a token"
+description: "Mark a token as deleted with TokenDeleteTransaction, signed by the admin key. Deleted tokens remain in the ledger but block further operations."
 ---
 
 

--- a/native/tokens/disable-kyc.mdx
+++ b/native/tokens/disable-kyc.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Disable KYC account flag"
+description: "Revoke the KYC flag from an account for a specific token with TokenRevokeKycTransaction, signed by the token's KYC key."
 ---
 
 

--- a/native/tokens/dissociate.mdx
+++ b/native/tokens/dissociate.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Dissociate tokens from an account"
+description: "Remove the association between a Hedera account and one or more tokens with TokenDissociateTransaction, freeing token relationships once balances are zero."
 ---
 
 

--- a/native/tokens/enable-kyc.mdx
+++ b/native/tokens/enable-kyc.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Enable KYC account flag"
+description: "Grant KYC to an account for a specific token with TokenGrantKycTransaction, signed by the token's KYC key."
 ---
 
 

--- a/native/tokens/errors.mdx
+++ b/native/tokens/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response Messages"
+description: "Reference of Hedera Token Service network response codes and what each status means when a token transaction succeeds or fails."
 ---
 
 

--- a/native/tokens/freeze.mdx
+++ b/native/tokens/freeze.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Freeze an account"
+description: "Freeze token transfers for a specific account with TokenFreezeTransaction, signed by the token's freeze key."
 ---
 
 

--- a/native/tokens/get-balance.mdx
+++ b/native/tokens/get-balance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get account token balance"
+description: "Get an account's token balances on Hedera. AccountBalanceQuery is deprecated and being throttled to zero, so migrate to the Mirror Node REST API balances endpoint."
 ---
 
 

--- a/native/tokens/get-info.mdx
+++ b/native/tokens/get-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get token info"
+description: "Query details about a fungible or non-fungible token with TokenInfoQuery, or use the recommended Mirror Node REST API."
 ---
 
 

--- a/native/tokens/get-nft-info.mdx
+++ b/native/tokens/get-nft-info.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get NFT info"
+description: "Query details about a specific NFT by its NFT ID, including owner, metadata, and any spender allowance, with TokenNftInfoQuery."
 ---
 
 

--- a/native/tokens/mint.mdx
+++ b/native/tokens/mint.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Mint a token"
+description: "Mint new units of a fungible token or create NFTs with unique metadata using TokenMintTransaction, signed by the token's supply key."
 ---
 
 

--- a/native/tokens/nft-id.mdx
+++ b/native/tokens/nft-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: "NFT ID"
+description: "Construct an NftId from a token ID and serial number to reference an individual non-fungible token on Hedera."
 ---
 
 

--- a/native/tokens/pause.mdx
+++ b/native/tokens/pause.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pause a token"
+description: "Pause a token with TokenPauseTransaction, signed by the pause key, to block all operations on it until it is unpaused."
 ---
 
 

--- a/native/tokens/reject-airdrop.mdx
+++ b/native/tokens/reject-airdrop.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reject a token"
+description: "Return unwanted airdropped tokens to the treasury with TokenRejectTransaction, rejecting fungible balances or specific NFT serials without paying custom fees."
 ---
 
 

--- a/native/tokens/token-id.mdx
+++ b/native/tokens/token-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token ID"
+description: "Construct and work with a TokenId, the 0.0.<num> identifier for a token created on the Hedera Token Service."
 ---
 
 

--- a/native/tokens/token-types.mdx
+++ b/native/tokens/token-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token types"
+description: "Compare the two Hedera Token Service token types: fungible (FUNGIBLE_COMMON) and non-fungible (NON_FUNGIBLE_UNIQUE) tokens."
 ---
 
 

--- a/native/tokens/transfer.mdx
+++ b/native/tokens/transfer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transfer tokens"
+description: "Transfer HBAR, fungible tokens, and NFTs between accounts in a single atomic TransferTransaction, including approved allowance transfers and tokens with custom fees."
 ---
 
 

--- a/native/tokens/unfreeze.mdx
+++ b/native/tokens/unfreeze.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Unfreeze an account"
+description: "Restore token transfers for a frozen account with TokenUnfreezeTransaction, signed by the token's freeze key."
 ---
 
 

--- a/native/tokens/unpause.mdx
+++ b/native/tokens/unpause.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Unpause a token"
+description: "Resume a previously paused token with TokenUnpauseTransaction, signed by the token's pause key, so it can participate in transactions again."
 ---
 
 

--- a/native/tokens/update-fee-schedule.mdx
+++ b/native/tokens/update-fee-schedule.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update token custom fees"
+description: "Change a token's custom fee schedule with TokenFeeScheduleUpdateTransaction, signed by the token's fee schedule key."
 ---
 
 

--- a/native/tokens/update-nft-metadata.mdx
+++ b/native/tokens/update-nft-metadata.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update NFT metadata"
+description: "Update the metadata of existing NFTs with TokenUpdateNftsTransaction, signed by the metadata key set at token creation."
 ---
 
 

--- a/native/tokens/update.mdx
+++ b/native/tokens/update.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update a token"
+description: "Update an existing token's properties such as name, symbol, treasury, keys, memo, and expiry with TokenUpdateTransaction, signed by the admin key."
 ---
 
 

--- a/native/tokens/wipe.mdx
+++ b/native/tokens/wipe.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wipe a token"
+description: "Remove fungible or non-fungible tokens from a specific account with TokenWipeTransaction, burning them and decreasing total supply."
 ---
 
 

--- a/native/transactions/batch.mdx
+++ b/native/transactions/batch.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a Batch Transaction"
+description: "Execute multiple transactions atomically in a single network call with BatchTransaction, so all inner operations succeed or fail together without requiring a smart contract."
 ---
 
 

--- a/native/transactions/index.mdx
+++ b/native/transactions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transactions"
+description: "Understand Hedera transactions: how clients submit requests to network nodes, how fees are calculated and paid in HBAR, size limits, and the transaction types for each service."
 ---
 
 

--- a/native/transactions/manual-sign.mdx
+++ b/native/transactions/manual-sign.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Manually sign a transaction"
+description: "Manually sign a transaction with the private keys it requires using sign(), signWith(), and related SDK methods, and learn when the operator key signs automatically on execute()."
 ---
 
 

--- a/native/transactions/multisig.mdx
+++ b/native/transactions/multisig.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sign a multisignature transaction"
+description: "Sign and submit a Hedera transaction that requires multiple keys, using a key list where every key must sign or a threshold key where only a subset is required."
 ---
 
 

--- a/native/transactions/receipt.mdx
+++ b/native/transactions/receipt.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get a transaction receipt"
+description: "Request a transaction receipt to confirm whether a transaction reached consensus on the Hedera network, available free of charge for up to 3 minutes after submission."
 ---
 
 

--- a/native/transactions/transaction-id.mdx
+++ b/native/transactions/transaction-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transaction ID"
+description: "Understand the Hedera transaction ID format of payer account ID plus timestamp, and how scheduled and child transactions extend it with schedule flags and nonce values."
 ---
 
 

--- a/native/tutorials/advanced/hashgraphdev.mdx
+++ b/native/tutorials/advanced/hashgraphdev.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Building on Hedera (course)"
+description: "A free online course that teaches you how to build applications on Hedera, hosted at hashgraphdev.com."
 url: "https://hashgraphdev.com/?code=docs.hedera.com"
 ---

--- a/native/tutorials/advanced/hcs-fabric-plugin/index.mdx
+++ b/native/tutorials/advanced/hcs-fabric-plugin/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Started with the Hedera Consensus Service Fabric Plugin
+description: "Build a Hyperledger Fabric network that uses the Hedera Consensus Service as its ordering service through the HCS Fabric plugin, with two organizations and peers."
 sidebarTitle: HCS Fabric Plugin
 ---
 <Warning>

--- a/native/tutorials/advanced/hcs-fabric-plugin/virtual-environment.mdx
+++ b/native/tutorials/advanced/hcs-fabric-plugin/virtual-environment.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Virtual Environment Setup"
+description: "Run the HCS Hyperledger Fabric sample network in a virtual environment using Vagrant and VirtualBox, from cloning the pluggable-hcs repository through setup."
 ---
 
 

--- a/native/tutorials/advanced/hsm-signing/azure-key-vault.mdx
+++ b/native/tutorials/advanced/hsm-signing/azure-key-vault.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sign Hedera Transactions with Azure Key Vault"
+description: "Set up a secp256k1 signing key in Azure Key Vault and use it to sign Hedera transactions from a Node.js app, keeping private keys out of your application."
 ---
 
 This guide provides a comprehensive walkthrough for setting up a **secp256k1 signing key in an Azure Key Vault (Premium SKU)** and using it to sign Hedera Hashgraph transactions with a Node.js application. It incorporates solutions to common Azure CLI and SDK integration issues.

--- a/native/tutorials/advanced/hsm-signing/index.mdx
+++ b/native/tutorials/advanced/hsm-signing/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: HSM/KMS Signing Solutions
+description: "Sign Hedera transactions with keys held in cloud KMS or HSM services so private keys never leave the secure store, using a custom SDK signer function."
 sidebarTitle: HSM Signing
 ---
 

--- a/native/tutorials/advanced/random-number.mdx
+++ b/native/tutorials/advanced/random-number.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Generate a Random Number on Hedera"
+description: "Generate verifiable pseudorandom numbers on Hedera with the JavaScript SDK and Solidity, so anyone can confirm the value came from the network unaltered."
 sidebarTitle: "Generate a Random Number"
 ---
 

--- a/native/tutorials/consensus/create-first-topic.mdx
+++ b/native/tutorials/consensus/create-first-topic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a Topic"
+description: "Create your first Hedera Consensus Service topic on testnet with the JavaScript, Java, Go, or Python SDK, and submit a message to it."
 ---
 
 Learn how to create a new topic and submit your first message on Hedera testnet using the JavaScript, Java, Go SDK, or Python. A **topic** on the **Hedera Consensus Service (HCS)** is like a public channel: anyone who knows the topic ID can publish timestamped messages, and anyone can subscribe to the stream from a mirror node.

--- a/native/tutorials/consensus/private-topic.mdx
+++ b/native/tutorials/consensus/private-topic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Submit Message to Private Topic"
+description: "Create a private HCS topic with a submit key so only authorized signers can post messages, then submit a signed message with the SDK."
 ---
 
 ## Summary

--- a/native/tutorials/consensus/query-mirror-node.mdx
+++ b/native/tutorials/consensus/query-mirror-node.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Query Messages with Mirror Node"
+description: "Query the Hedera mirror node API to retrieve and filter messages submitted to an HCS topic, and read them back in consensus order."
 ---
 
 

--- a/native/tutorials/consensus/submit-first-message.mdx
+++ b/native/tutorials/consensus/submit-first-message.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Submit Your First Message"
+description: "Submit your first message to a Hedera Consensus Service topic with the SDK, and learn how HCS provides fair ordering and transparency for events."
 ---
 
 ## Summary

--- a/native/tutorials/getting-started/create-api-key.mdx
+++ b/native/tutorials/getting-started/create-api-key.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Create a Personal Access Token (API Key) on the Hedera Portal"
+description: "Create a Personal Access Token in the Hedera Portal to recreate accounts after testnet resets, query account IDs, and authenticate Faucet API requests."
 sidebarTitle: "Create an API Key"
 ---
 

--- a/native/tutorials/getting-started/create-fund-account.mdx
+++ b/native/tutorials/getting-started/create-fund-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create and Fund Your Hedera Testnet Account"
+description: "Create and fund a Hedera testnet account with HBAR using the developer portal, the faucet, or the HashPack wallet, so you can pay for transactions and queries."
 ---
 
 

--- a/native/tutorials/more/index.mdx
+++ b/native/tutorials/more/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: More Tutorials
+description: "Browse additional Hedera tutorials across developer tools, the basics, smart contracts, and NFTs and fungible tokens."
 ---
 <Columns cols={2}>
   <Card

--- a/native/tutorials/scheduled/schedule-first.mdx
+++ b/native/tutorials/scheduled/schedule-first.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedule Your First Transaction"
+description: "Create, sign, and execute your first scheduled transaction on Hedera with the SDK, and collect additional signatures with ScheduleSign before it runs."
 ---
 
 

--- a/native/tutorials/tokens/create-first-token.mdx
+++ b/native/tutorials/tokens/create-first-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create a Token"
+description: "Launch your first fungible token on Hedera testnet with the Hedera Token Service and the SDK, using your operator account as the treasury."
 ---
 
 Learn how to launch a simple fungible token on Hedera testnet. A fungible token is a divisible digital asset (think loyalty points, stablecoins, or stocks) created by the **Hedera Token Service (HTS)**.

--- a/native/tutorials/tokens/create-transfer-fungible.mdx
+++ b/native/tutorials/tokens/create-transfer-fungible.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create and Transfer Your First Fungible Token"
+description: "Create and transfer your first fungible token with the Hedera Token Service and the SDK, from token creation through associating accounts and moving balances."
 ---
 
 <Warning>

--- a/native/tutorials/tokens/create-transfer-nft.mdx
+++ b/native/tutorials/tokens/create-transfer-nft.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create and Transfer Your First NFT"
+description: "Create and transfer your first NFT with the Hedera Token Service and the SDK, from minting serial numbers to associating accounts and transferring ownership."
 ---
 
 <Warning>

--- a/native/tutorials/tokens/hts-part1-mint.mdx
+++ b/native/tutorials/tokens/hts-part1-mint.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Token Service - Part 1: How to Mint NFTs"
+description: "Mint and transfer your first NFT with the Hedera Token Service and the JavaScript SDK, no smart contract required, in part 1 of the HTS tutorial series."
 sidebarTitle: "HTS Part 1: Mint NFTs"
 ---
 

--- a/native/tutorials/tokens/hts-part2-kyc.mdx
+++ b/native/tutorials/tokens/hts-part2-kyc.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Token Service - Part 2: KYC, Update, and Scheduled Transactions"
+description: "Enable and disable a token KYC flag, update token properties on mutable tokens, and schedule token transfers with the Hedera Token Service in part 2 of the HTS series."
 sidebarTitle: "HTS Part 2: KYC & Update"
 ---
 

--- a/native/tutorials/tokens/hts-part3-admin.mdx
+++ b/native/tutorials/tokens/hts-part3-admin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Token Service - Part 3: How to Pause, Freeze, Wipe, and Delete NFTs"
+description: "Manage tokens with HTS admin keys: pause a token, freeze an account, wipe a balance, and delete a token, in part 3 of the Hedera Token Service series."
 sidebarTitle: "HTS Part 3: Admin Keys"
 ---
 

--- a/native/tutorials/tokens/metadata-schema.mdx
+++ b/native/tutorials/tokens/metadata-schema.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Structure Your Token Metadata Using JSON Schema V2"
+description: "Structure token metadata with the HIP-412 Token Metadata JSON Schema V2 so explorers and tooling on Hedera can read attributes like NFT rarity."
 ---
 
 ## Summary

--- a/operators/consensus-node/deployment.mdx
+++ b/operators/consensus-node/deployment.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Node Deployment Process"
+description: "Step-by-step process for Hedera Council members to deploy a permissioned consensus node on mainnet, from infrastructure setup to onboarding."
 ---
 
 

--- a/operators/consensus-node/index.mdx
+++ b/operators/consensus-node/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Mainnet Consensus Nodes
+description: "Reference for Hedera mainnet consensus nodes: the node address book, node account IDs and endpoints, certificate thumbprints, and public keys."
 mode: "wide"
 ---
 Hedera networks are comprised of two types of nodes: Consensus and Mirror nodes. The Hedera Mainnet **consensus nodes** are currently permissioned; operated by the Hedera Council. Consensus nodes receive transactions from clients, charge transaction fees, and contribute to consensus being achieved. **Mirror nodes** are permissionless, and store the history of transactions for optimized queries. Mirror nodes do not submit transactions to the network from clients nor do they participate in consensus.

--- a/operators/mirror-node/index.mdx
+++ b/operators/mirror-node/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Mirror Node"
+description: "Connect to Hedera mirror nodes: public mainnet, testnet, and previewnet gRPC and REST endpoints, TLS requirements, SDK setup, and rate limits."
 ---
 
 

--- a/operators/mirror-node/one-click-deploy.mdx
+++ b/operators/mirror-node/one-click-deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "One-Click Deployment"
+description: "Deploy your own Hedera mirror node from the Google Cloud Platform Marketplace, then reach it through the gRPC and REST APIs."
 ---
 
 

--- a/operators/mirror-node/run-your-own/gcs.mdx
+++ b/operators/mirror-node/run-your-own/gcs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Run Your Own Mirror Node with Google Cloud Storage (GCS)"
+description: "Run your own Hedera mirror node using Google Cloud Storage: generate HMAC keys, configure application.yml, and query the data with Docker and PostgreSQL."
 sidebarTitle: "Google Cloud Storage (GCS)"
 ---
 

--- a/operators/mirror-node/run-your-own/index.mdx
+++ b/operators/mirror-node/run-your-own/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Run Your Own Mirror Node
+description: "Run your own Hedera mirror node to pull transaction records and account balance files from cloud storage, with hardware requirements and cost estimates."
 sidebarTitle: Run Your Own
 ---
 <Tip>

--- a/operators/mirror-node/run-your-own/s3.mdx
+++ b/operators/mirror-node/run-your-own/s3.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Run Your Mirror Node with Amazon Web Services S3 (AWS)"
+description: "Run your own Hedera mirror node using AWS S3: create an IAM user, configure application.yml with your access keys, and query the data with Docker and PostgreSQL."
 sidebarTitle: "Amazon S3 (AWS)"
 ---
 

--- a/reference/network-responses.mdx
+++ b/reference/network-responses.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Response Codes"
+description: "Reference table of Hedera network response codes and their descriptions, from AUTORENEW_DURATION_NOT_IN_RANGE to transaction and query validation errors."
 sidebarTitle: "Response Codes"
 ---
 

--- a/reference/rest-api/accounts/index.mdx
+++ b/reference/rest-api/accounts/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Accounts"
+description: "Retrieve account details, crypto allowances, token relationships, NFTs, and staking rewards on Hedera with the Mirror Node REST API account endpoints."
 ---
 
 

--- a/reference/rest-api/balances/index.mdx
+++ b/reference/rest-api/balances/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Balances"
+description: "Query real-time and historical account balances on Hedera with the Mirror Node REST API, returning account IDs and HBAR balances from periodic snapshots."
 ---
 
 

--- a/reference/rest-api/blocks/index.mdx
+++ b/reference/rest-api/blocks/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Blocks"
+description: "Query block data on Hedera with the Mirror Node REST API: list blocks and fetch block metadata such as hashes, timestamps, and transactions."
 ---
 
 

--- a/reference/rest-api/contracts/index.mdx
+++ b/reference/rest-api/contracts/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Contracts"
+description: "Query smart contract metadata, execution results, state changes, and logs on Hedera with the Mirror Node REST API contract endpoints."
 ---
 
 

--- a/reference/rest-api/schedules/index.mdx
+++ b/reference/rest-api/schedules/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedule Transactions"
+description: "Query scheduled transactions on Hedera with the Mirror Node REST API: list schedules and fetch execution status and metadata by schedule ID."
 sidebarTitle: Schedules
 ---
 

--- a/reference/rest-api/tokens/index.mdx
+++ b/reference/rest-api/tokens/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tokens"
+description: "Retrieve token details, token balances, NFT metadata, and transaction history on Hedera with the Mirror Node REST API token endpoints."
 ---
 
 

--- a/reference/rest-api/topics/index.mdx
+++ b/reference/rest-api/topics/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Topics"
+description: "Query HCS topics and messages on Hedera with the Mirror Node REST API: retrieve topic details, message history, and messages by sequence number or timestamp."
 ---
 
 

--- a/reference/rest-api/transactions/index.mdx
+++ b/reference/rest-api/transactions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transactions"
+description: "Query transaction history, details, and status on Hedera with the Mirror Node REST API: track payments, token transfers, and smart contract executions."
 ---
 
 

--- a/reference/status-api.mdx
+++ b/reference/status-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Status API"
+description: "Programmatically access the Hedera network's operational status, incident reports, and scheduled maintenance to monitor system health in your applications."
 sidebarTitle: Status API
 ---
 

--- a/reference/verification-api.mdx
+++ b/reference/verification-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Contract Verification API"
+description: "Verify smart contracts on Hedera with the Sourcify API: submit source and metadata, track verification jobs, and look up verified contracts by address and chain ID."
 sidebarTitle: Verification API
 ---
 

--- a/solutions/examples/demos.mdx
+++ b/solutions/examples/demos.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Demo Applications"
+description: "Browse demo applications built on Hedera across Java, JavaScript, and other languages, from the JSON-RPC relay to HCS integrations and transaction tooling."
 ---
 
 

--- a/solutions/examples/starters.mdx
+++ b/solutions/examples/starters.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Starter Projects"
+description: "Starter project templates for building Hedera applications in Java, JavaScript, and more, maintained by Hedera and the community."
 ---
 
 

--- a/solutions/governance/hashiodao/governance-token-dao.mdx
+++ b/solutions/governance/hashiodao/governance-token-dao.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Governance Token DAO"
+description: "Create a governance token DAO on Hedera with HashioDAO, giving decision-making power to token holders through proposals and on-chain voting."
 ---
 
 

--- a/solutions/governance/hashiodao/index.mdx
+++ b/solutions/governance/hashiodao/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: HashioDAO
+description: "Learn how DAOs work and how HashioDAO lets communities create and manage decentralized organizations on Hedera with governance token, NFT, and multisig models."
 ---
 ## **Introduction**
 

--- a/solutions/governance/hashiodao/local-environment-setup.mdx
+++ b/solutions/governance/hashiodao/local-environment-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Local Environment Setup"
+description: "Set up and configure a local HashioDAO environment: clone the repo, secure local wallet pairings, and configure Pinata IPFS API environment variables."
 ---
 
 

--- a/solutions/governance/hashiodao/multisig-dao.mdx
+++ b/solutions/governance/hashiodao/multisig-dao.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Multisig DAO"
+description: "Create a multisig DAO on Hedera with HashioDAO: connect a wallet, define your DAO, and require multiple members to authorize and sign transactions."
 ---
 
 

--- a/solutions/governance/hashiodao/nft-dao.mdx
+++ b/solutions/governance/hashiodao/nft-dao.mdx
@@ -1,5 +1,6 @@
 ---
 title: "NFT DAO"
+description: "Create an NFT-based DAO on Hedera with HashioDAO, giving voting power to holders of a specific NFT, with support for features like soulbound tokens."
 ---
 
 

--- a/solutions/sustainability/guardian.mdx
+++ b/solutions/sustainability/guardian.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera Guardian"
+description: "Hedera Guardian: an open-source platform for building auditable environmental asset markets, digital MRV systems, and tokenized carbon and sustainability credits."
 url: "https://guardian.hedera.com/"
 ---

--- a/solutions/tokenization/nft-studio/airdrop-verifier.mdx
+++ b/solutions/tokenization/nft-studio/airdrop-verifier.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Airdrop List Verifier"
+description: "Use the Airdrop List Verifier to check which accounts are associated with a Hedera token or have open auto-association slots before running an airdrop."
 ---
 
 The [Airdrop List Verifier](https://nft-studio.hashgraph.com/airdrop-list-verifier/) is a tool that streamlines organizing airdrops for Hedera tokens. By inputting a token ID and a list of account IDs, users can quickly verify which accounts are either associated with the token or have available auto-association slots. This tutorial will guide you through generating a refined list of eligible accounts, enabling efficient and targeted airdrops.

--- a/solutions/tokenization/nft-studio/balance-snapshot.mdx
+++ b/solutions/tokenization/nft-studio/balance-snapshot.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Balance Snapshot"
+description: "Use the Token Balance Snapshot tool to capture how tokens are distributed across accounts, filtered by minimum amount and date, for airdrops and rewards."
 ---
 
 

--- a/solutions/tokenization/nft-studio/index.mdx
+++ b/solutions/tokenization/nft-studio/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: NFT Studio
+description: "NFT Studio is a free, open-source toolkit for creating and managing NFTs on Hedera: mint tokens, validate metadata, calculate rarity, and analyze holders."
 ---
 
 ## Introduction to NFT Studio

--- a/solutions/tokenization/nft-studio/metadata-validator.mdx
+++ b/solutions/tokenization/nft-studio/metadata-validator.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Metadata Validator"
+description: "Validate your NFT metadata against the HIP-412 standard by uploading CSV, JSON, or zip files, then find and correct errors before minting."
 ---
 
 The [Metadata Validator](https://nft-studio.hashgraph.com/metadata-validator/) is built to check your NFT metadata against the [HIP-412](https://hips.hedera.com/hip/hip-412) _(NFT Token Metadata JSON Schema v2)_ standards, ensuring proper representation. You can validate metadata by uploading a CSV file, a single JSON file, or a zip file containing multiple JSON files. The tool identifies errors or missing fields, allowing for easy corrections and ensuring compliance with standards. This tutorial will guide you through uploading, validating, and correcting your NFT metadata for seamless compliance.

--- a/solutions/tokenization/nft-studio/rarity-inspector.mdx
+++ b/solutions/tokenization/nft-studio/rarity-inspector.mdx
@@ -1,5 +1,6 @@
 ---
 title: "NFT Rarity Inspector"
+description: "Use the NFT Rarity Inspector to upload a collection, validate HIP-412 metadata, and calculate a rarity score for each NFT based on its traits."
 ---
 
 The [NFT Rarity Inspector](https://nft-studio.hashgraph.com/nft-rarity-inspector/) allows users to upload a `.zip` file to verify NFT metadata and check for compliance with [HIP-412 standards](https://hips.hedera.com/hip/hip-412). It calculates a rarity score by analyzing the NFT's traits, features, and properties compared to the entire collection. Once the inspection is complete, each NFT is assigned a rarity score based on its uniqueness, helping artists, collectors, and traders understand its value. The higher the score, the rarer and more unique the NFT, making it more valuable than those with lower scores.

--- a/solutions/tokenization/nft-studio/risk-calculator.mdx
+++ b/solutions/tokenization/nft-studio/risk-calculator.mdx
@@ -1,5 +1,6 @@
 ---
 title: "NFT Risk Calculator"
+description: "Use the NFT Risk Calculator to score a Hedera token's rug-pull risk based on its Admin, Supply, and KYC key configuration before creating or acquiring it."
 ---
 
 The [NFT Risk Calculator](https://nft-studio.hashgraph.com/nft-risk-calculator/) evaluates the potential risk associated with tokens on the Hedera network, focusing on the likelihood of a "[rug pull](/support/glossary#rug-pull)" based on specific token properties. The risk calculator generates a comprehensive risk score and risk level by analyzing key factors, such as the Admin Key, Supply Key, and KYC Key. The calculator can be used to assess both existing tokens and those you plan to create, gaining insights into how specific properties may make a collection more or less risky. This helps developers and token creators make informed decisions about token security and governance.

--- a/solutions/tokenization/nft-studio/token-holders-list.mdx
+++ b/solutions/tokenization/nft-studio/token-holders-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "NFT Token Holders List Builder"
+description: "Use the NFT Token Holders List Builder to compile lists of accounts by token ownership, filtered by holdings, duration, or start date for targeted airdrops."
 ---
 
 The [NFT Token Holders List Builder](https://nft-studio.hashgraph.com/token-holders-list-builder/) streamlines the process of compiling a list of wallet accounts based on specific token ownership criteria, making airdrops and community engagement more targeted and efficient. You can specify one or more token IDs to filter eligible accounts and set conditions like minimum token holdings, duration of ownership, or even a specific start date for holding the NFT. This tool enables you to easily build a tailored list of accounts that qualify for your new token distribution or NFT collection drop.

--- a/solutions/tokenization/stablecoin/cli.mdx
+++ b/solutions/tokenization/stablecoin/cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: "CLI Management"
+description: "Install and configure the Stablecoin Studio SDK and CLI, then create and operate stablecoins on Hedera from the command line, including proof-of-reserve setup."
 ---
 
 

--- a/solutions/tokenization/stablecoin/core-concepts.mdx
+++ b/solutions/tokenization/stablecoin/core-concepts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Core Concepts"
+description: "Learn what stablecoins are and how Stablecoin Studio uses HTS and smart contracts to issue them on Hedera with access control, KYC/AML flags, and proof-of-reserve."
 ---
 
 

--- a/solutions/tokenization/stablecoin/web-ui.mdx
+++ b/solutions/tokenization/stablecoin/web-ui.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Web UI Application"
+description: "Manage stablecoins on Hedera through the Stablecoin Studio React web application: run the interactive demo and handle setup through advanced administration."
 ---
 
 

--- a/solutions/tools/code-repo.mdx
+++ b/solutions/tools/code-repo.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Developers Code Repository"
+description: "Explore the hedera-dev GitHub organization: code snippets, end-to-end demos, workshop materials, and reference implementations for building on Hedera."
 ---
 
 

--- a/solutions/tools/custodians-library-usage.mdx
+++ b/solutions/tools/custodians-library-usage.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How to Use the Hedera Custodians Library"
+description: "Install and use the Hedera Custodians Library: create a Fireblocks or DFNS custodial wallet service and sign account operations from TypeScript."
 sidebarTitle: "Usage Guide"
 ---
 

--- a/solutions/tools/custodians-library.mdx
+++ b/solutions/tools/custodians-library.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hedera Custodians Library
+description: "A TypeScript library that simplifies custodial wallet management and account operations on Hedera, with a unified interface for services like Fireblocks and DFNS."
 sidebarTitle: Custodians Library
 ---
 ## Introduction

--- a/solutions/tools/hiero-cli/overview.mdx
+++ b/solutions/tools/hiero-cli/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: "Get started with the Hiero CLI, a command-line tool for interacting with the Hedera network: install it, configure an operator, and run common network operations."
 ---
 
 ## Introduction to Hiero CLI

--- a/solutions/tools/hiero-cli/plugins/account-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/account-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account Plugin"
+description: "Command reference for the Hiero CLI account plugin: create Hedera accounts, check balances, and list accounts from the command line."
 ---
 
 ## Most Used Commands

--- a/solutions/tools/hiero-cli/plugins/batch-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/batch-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Batch Plugin"
+description: "Command reference for the Hiero CLI batch plugin: queue signed inner transactions and execute them together as one atomic Hedera batch transaction."
 ---
 
 ## Most Used Commands

--- a/solutions/tools/hiero-cli/plugins/config-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/config-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Config Plugin"
+description: "Command reference for the Hiero CLI config plugin: list, get, and set configuration options that control CLI behavior."
 ---
 ## Full Command Reference
 

--- a/solutions/tools/hiero-cli/plugins/contract-erc20-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/contract-erc20-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Contract ERC-20 Plugin"
+description: "Command reference for the Hiero CLI Contract ERC-20 plugin: call standard EIP-20 methods like name, balanceOf, transfer, and approve on deployed Hedera contracts."
 ---
 
 The **Contract ERC-20** plugin calls standard **EIP-20** methods on a contract already deployed on Hedera. Deploy or import the contract first with the [Contract plugin](/solutions/tools/hiero-cli/plugins/contract-plugin).

--- a/solutions/tools/hiero-cli/plugins/contract-erc721-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/contract-erc721-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Contract ERC-721 Plugin"
+description: "Command reference for the Hiero CLI Contract ERC-721 plugin: call standard EIP-721 methods like ownerOf, tokenURI, approve, and safeTransferFrom on Hedera NFT contracts."
 ---
 
 The **Contract ERC-721** plugin calls standard **EIP-721** methods on an NFT collection contract deployed on Hedera. Deploy or import the contract first with the [Contract plugin](/solutions/tools/hiero-cli/plugins/contract-plugin). For fungible (ERC-20) calls, see the [Contract ERC-20 plugin](/solutions/tools/hiero-cli/plugins/contract-erc20-plugin).

--- a/solutions/tools/hiero-cli/plugins/contract-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/contract-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Contract Plugin"
+description: "Command reference for the Hiero CLI contract plugin: deploy Solidity contracts, import existing on-chain contracts, and manage contracts on Hedera."
 ---
 
 ## Most Used Commands

--- a/solutions/tools/hiero-cli/plugins/credentials-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/credentials-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Credentials Plugin"
+description: "Command reference for the Hiero CLI credentials plugin: list and remove key references stored in the CLI's key management storage."
 ---
 
 ## Full Command Reference

--- a/solutions/tools/hiero-cli/plugins/hbar-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/hbar-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HBAR Plugin"
+description: "Command reference for the Hiero CLI HBAR plugin: transfer HBAR in whole units or tinybars between accounts, with options for memos, source accounts, and key managers."
 ---
 
 ## Full Command Reference

--- a/solutions/tools/hiero-cli/plugins/network-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/network-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Plugin"
+description: "Command reference for the Hiero CLI network plugin: list networks, switch between mainnet, testnet, previewnet, and localnet, and manage operator credentials."
 ---
 
 ## Full Command Reference

--- a/solutions/tools/hiero-cli/plugins/plugin-management-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/plugin-management-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Plugin Management Plugin"
+description: "Command reference for the Hiero CLI plugin management plugin: add, remove, enable, and disable built-in and custom CLI plugins."
 ---
 
 

--- a/solutions/tools/hiero-cli/plugins/schedule-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/schedule-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Schedule Plugin"
+description: "Command reference for the Hiero CLI schedule plugin: create Hedera scheduled transactions, sign them, and verify their status before execution."
 ---
 
 ## Most Used Commands

--- a/solutions/tools/hiero-cli/plugins/swap-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/swap-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Swap Plugin"
+description: "Command reference for the Hiero CLI swap plugin: compose multi-party exchanges of HBAR, HTS tokens, and NFT serials and execute them as one CryptoTransfer."
 ---
 
 Multi-party exchanges of **HBAR**, **fungible HTS tokens**, and **NFT serials**, composed step by step locally and executed as **one Hedera transfer transaction** (`CryptoTransfer`). If the submission fails (for example insufficient balance), the saved swap stays in CLI state unless you **`swap delete`** it.

--- a/solutions/tools/hiero-cli/plugins/token-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/token-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Plugin"
+description: "Command reference for the Hiero CLI token plugin: create fungible and non-fungible tokens, associate accounts, and transfer tokens on Hedera."
 ---
 
 ## Most Used Commands

--- a/solutions/tools/hiero-cli/plugins/topic-plugin.mdx
+++ b/solutions/tools/hiero-cli/plugins/topic-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Topic Plugin"
+description: "Command reference for the Hiero CLI topic plugin: create Hedera Consensus Service topics, submit messages, and find messages by sequence range."
 ---
 
 ## Most Used Commands

--- a/solutions/tools/hiero-cli/scripting/quickstart.mdx
+++ b/solutions/tools/hiero-cli/scripting/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quickstart"
+description: "Run repeatable, non-interactive Hiero CLI scripts for Hedera workflows like creating accounts, transferring HBAR, and submitting topic messages, safe for CI."
 ---
 
 ## Scripting with Hiero CLI

--- a/solutions/tools/nft-sdk-redirect.mdx
+++ b/solutions/tools/nft-sdk-redirect.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera NFT SDK"
+description: "The Hedera NFT SDK: a TypeScript toolkit for minting NFTs, validating HIP-412 metadata, calculating rarity, and building token holder lists."
 url: "https://github.com/hashgraph/hedera-nft-sdk"
 ---

--- a/solutions/tools/stablecoin-sdk-redirect.mdx
+++ b/solutions/tools/stablecoin-sdk-redirect.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Stablecoin Studio SDK"
+description: "The Stablecoin Studio TypeScript SDK for programmatically creating and managing stablecoins backed by Hedera Token Service and smart contracts."
 url: "https://github.com/hashgraph/stablecoin-studio/tree/main/packages/sdk"
 ---

--- a/solutions/tools/wallet-snap-intro.mdx
+++ b/solutions/tools/wallet-snap-intro.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera Wallet Snap"
+description: "Add Hedera support to MetaMask with the Hedera Wallet Snap: manage accounts, send HBAR, and interact with Hedera services directly from MetaMask."
 url: "https://docs.tuum.tech/hedera-wallet-snap/basics/introduction"
 ---

--- a/solutions/tools/walletconnect-redirect.mdx
+++ b/solutions/tools/walletconnect-redirect.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera WalletConnect"
+description: "Connect wallets to your Hedera dApp with the Hedera WalletConnect library, the standard for pairing wallets and signing transactions over WalletConnect."
 url: "https://github.com/hashgraph/hedera-wallet-connect?tab=readme-ov-file#overview"
 ---

--- a/support/brand-guidelines.mdx
+++ b/support/brand-guidelines.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Brand Guidelines"
+description: "Use official Hedera logos, iconography, and the Decentralized on Hedera stamp correctly, with guidance for light and dark backgrounds."
 ---
 
 

--- a/support/contributing/contribution-guidelines/creating-issues.mdx
+++ b/support/contributing/contribution-guidelines/creating-issues.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Creating Issues"
+description: "Report a documentation problem or suggest new content by opening an issue in the hedera-docs GitHub repository, step by step."
 ---
 
 

--- a/support/contributing/contribution-guidelines/hip.mdx
+++ b/support/contributing/contribution-guidelines/hip.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Hedera Improvement Proposal (HIP)"
+description: "Propose a new feature or standard for Hedera by submitting a Hedera Improvement Proposal: fork the repo, complete the HIP template, and open a pull request."
 ---
 
 

--- a/support/contributing/contribution-guidelines/submit-demo.mdx
+++ b/support/contributing/contribution-guidelines/submit-demo.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Submit Demo Applications"
+description: "Share your Hedera demo application by opening an enhancement issue in the hedera-docs repository with the required details for review."
 ---
 
 

--- a/support/contributing/style-guide/gitbook-markdown-syntax.mdx
+++ b/support/contributing/style-guide/gitbook-markdown-syntax.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Gitbook Markdown Syntax"
+description: "Reference for the Markdown syntax supported in the docs, covering formatting conventions used across Hedera documentation pages."
 url: "https://raw.githubusercontent.com/audacity/audacity-support/main/community/contributing/tutorials/gitbook-markdown-syntax.md"
 ---

--- a/support/contributing/style-guide/use-of-mainnet-testnet-and-previewnet.mdx
+++ b/support/contributing/style-guide/use-of-mainnet-testnet-and-previewnet.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Use of mainnet, testnet, and previewnet"
+description: "Style-guide rule for writing network names: always lowercase mainnet, testnet, and previewnet, even when preceded by Hedera."
 ---
 
 

--- a/support/faq/community.mdx
+++ b/support/faq/community.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Community"
+description: "Answers to common questions about the Hedera developer community, including funding programs, grants, and where to get support on Discord."
 ---
 
 <AccordionGroup>

--- a/support/faq/getting-started.mdx
+++ b/support/faq/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+description: "Answers to common getting-started questions on Hedera: the developer portal, and creating accounts on mainnet, testnet, and previewnet."
 ---
 
 ## Developer Portal

--- a/support/faq/governance.mdx
+++ b/support/faq/governance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Governance"
+description: "Answers to common questions about Hedera network governance: censorship resistance, the Hedera Council, scheduled maintenance, and network throttling."
 ---
 
 <AccordionGroup>

--- a/support/faq/hbar.mdx
+++ b/support/faq/hbar.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HBAR"
+description: "Answers to common questions about HBAR, including the official cryptocurrency denominations such as tinybars, microbar, and millibar."
 ---
 
 <AccordionGroup>

--- a/support/forms.mdx
+++ b/support/forms.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Documentation Survey"
+description: "Share feedback on the Hedera documentation through a short survey to help improve the developer docs."
 url: "https://forms.gle/x2bkUbLMqBfyndqH7"
 ---

--- a/support/github-com-hashgraph.mdx
+++ b/support/github-com-hashgraph.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Github"
+description: "Browse Hedera open-source repositories on GitHub, including SDKs, sample code, and core network projects."
 url: "https://github.com/hashgraph"
 ---

--- a/support/hedera-com-blog-tagged-technical.mdx
+++ b/support/hedera-com-blog-tagged-technical.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera Blog"
+description: "Read technical posts on the Hedera blog covering network features, developer tooling, and engineering deep dives."
 url: "https://hedera.com/blog/tagged/technical"
 ---

--- a/support/hedera-com-bounty.mdx
+++ b/support/hedera-com-bounty.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Bug Bounty"
+description: "Report security vulnerabilities through the Hedera bug bounty program and learn how researchers are rewarded for responsible disclosure."
 url: "https://hedera.com/bounty"
 ---

--- a/support/hedera-com-discord.mdx
+++ b/support/hedera-com-discord.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Discord"
+description: "Join the Hedera Discord to ask questions, share projects, and connect with other developers building on the network."
 url: "https://hedera.com/discord"
 ---

--- a/support/help-hedera-com-hc-en-us.mdx
+++ b/support/help-hedera-com-hc-en-us.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Hedera Help"
+description: "Visit the Hedera Help Center for support articles, account and portal help, and answers to common questions about using the network."
 url: "https://help.hedera.com/hc/en-us"
 ---

--- a/support/status-hedera-com.mdx
+++ b/support/status-hedera-com.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Status Page"
+description: "Check the real-time operational status of the Hedera network, including incidents and scheduled maintenance for mainnet and testnet."
 url: "https://status.hedera.com"
 ---


### PR DESCRIPTION
## summary

part 2 of #732 that addresses the highest-leverage item (item 1): frontmatter `description` coverage. adds a `description` to 278 pages that were missing one. mintlify uses this field for the page summary in `llms.txt`, `llms-full.txt`, per-page `.md` exports, mcp `search_hedera` snippets, and on-site search, so filling the gap improves both ai discoverability and seo in one pass.

## coverage

| tab | pages |
|-----|-------|
| evm | 67 |
| native | 115 |
| solutions | 41 |
| reference (non-protobuf) + operators + support | 35 |
| learn | 20 |

protobuf reference pages (~144) are intentionally deferred (auto-generated, terminology-exempt, low value-per-effort).

## not in this pr

- item 6 (`api.openapi` in `docs.json`) and a few pre-existing page-body bugs found during review are handled separately.
